### PR TITLE
Использовать название в качестве суффикса

### DIFF
--- a/lib/versionbuilder.php
+++ b/lib/versionbuilder.php
@@ -66,9 +66,10 @@ abstract class VersionBuilder extends AbstractBuilder
 
     protected function getVersionName()
     {
-        return $this->purifyPrefix(
-                $this->getFieldValue('prefix')
-            ) . $this->getTimestamp();
+        return strtr($this->getVersionConfig()->getVal('version_name_template'), [
+            '#NAME#' => $this->purifyPrefix($this->getFieldValue('prefix')),
+            '#TIMESTAMP#' => $this->getTimestamp(),
+        ]);
     }
 
     protected function createVersionFile($templateFile = '', $templateVars = [])

--- a/lib/versionconfig.php
+++ b/lib/versionconfig.php
@@ -253,6 +253,9 @@ class VersionConfig
             $values['version_schemas'] = $this->getDefaultSchemas();
         }
 
+        if (!isset($values['version_name_template'])) {
+            $values['version_name_template'] = '#NAME##TIMESTAMP#';
+        }
 
         ksort($values);
         return $values;

--- a/lib/versionmanager.php
+++ b/lib/versionmanager.php
@@ -519,16 +519,16 @@ class VersionManager
     public function getVersionTimestamp($versionName)
     {
         $matches = [];
-        if (preg_match('/[0-9]{14}$/', $versionName, $matches)) {
-            return $matches[0];
-        } else {
-            return false;
+        if (preg_match('/\d{14}/', $versionName, $matches)) {
+            return end($matches);
         }
+
+        return false;
     }
 
     protected function purifyDescriptionForMeta($descr = '')
     {
-        $descr = strval($descr);
+        $descr = (string)$descr;
         $descr = str_replace(["\n\r", "\r\n", "\n", "\r"], ' ', $descr);
         $descr = strip_tags($descr);
         $descr = stripslashes($descr);


### PR DESCRIPTION
Добавил в конфиг опцию `version_use_suffix`, которая позволяет использовать название миграции в качестве суффикса в названии файла. Со включенной опцией файлы создаются по шаблону `<config-prefix><timestamp>_<name>`.

Такой подход к именованию удобнее, при просмотре списка файлов миграций, видно в каком порядке они идут. В то же время, это лишь опция, изначальное поведение модуля не меняется.