### PR TITLE
Fix: use strict comparison in hasDiff

### DIFF
--- a/lib/helper.php
+++ b/lib/helper.php
@@ -140,7 +140,7 @@ class Helper
 
     protected function hasDiff($exists, $fields)
     {
-        return ($exists != $fields);
+        return ($exists !== $fields);
     }
 
     /**


### PR DESCRIPTION
Столкнулся с проблемой при миграции Форм редактирования.
В случае, если меняется сортировка полей, нестрогое сравнение не видит различий.

```php
$exists = ['Элемент|edit1' => ['NAME' => 'Название', 'SORT' => 'Сортировка']];
$fields = ['Элемент|edit1' => ['SORT' => 'Сортировка', 'NAME' => 'Название']];
var_dump(($exists != $fields)); // false wrong
var_dump(($exists !== $fields)); // true correct
```