### PR TITLE
Избавился от $_POST и $_REQUEST

### DIFF
--- a/admin/includes/interface.php
+++ b/admin/includes/interface.php
@@ -2,28 +2,33 @@
 
 use Sprint\Migration\Locale;
 use Sprint\Migration\Out;
+use Bitrix\Main\Application;
+
+$request = Application::getInstance()->getContext()->getRequest();
+$requestArray = $request->getPostList()->toArray() + $request->getQueryList()->toArray();
+
 
 $APPLICATION->SetTitle(Locale::getMessage('TITLE'));
 
-if ($_SERVER["REQUEST_METHOD"] == "POST") {
+if ($request->isPost()) {
     CUtil::JSPostUnescape();
 }
 
-if (isset($_REQUEST['schema'])) {
-    $versionConfig = new Sprint\Migration\VersionConfig($_REQUEST['schema']);
-} elseif (isset($_REQUEST['config'])) {
-    $versionConfig = new Sprint\Migration\VersionConfig($_REQUEST['config']);
+if (isset($requestArray['schema'])) {
+    $versionConfig = new Sprint\Migration\VersionConfig($requestArray['schema']);
+} elseif (isset($requestArray['config'])) {
+    $versionConfig = new Sprint\Migration\VersionConfig($requestArray['config']);
 } else {
     $versionConfig = new Sprint\Migration\VersionConfig();
 }
 
 if ($versionConfig->getVal('show_admin_interface')) {
-    if ($_SERVER["REQUEST_METHOD"] == "POST") {
+    if ($request->isPost()) {
         /** @noinspection PhpIncludeInspection */
         require_once($_SERVER["DOCUMENT_ROOT"] . "/bitrix/modules/main/include/prolog_admin_js.php");
 
         try {
-            if (isset($_REQUEST['schema'])) {
+            if (isset($requestArray['schema'])) {
                 include __DIR__ . '/../steps/schema_list.php';
                 include __DIR__ . '/../steps/schema_export.php';
                 include __DIR__ . '/../steps/schema_import.php';
@@ -52,7 +57,7 @@ require($_SERVER["DOCUMENT_ROOT"] . "/bitrix/modules/main/include/prolog_admin_a
 CUtil::InitJSCore(["jquery"]);
 
 if ($versionConfig->getVal('show_admin_interface')) {
-    if (isset($_REQUEST['schema'])) {
+    if (isset($requestArray['schema'])) {
         include __DIR__ . '/../includes/schema.php';
         include __DIR__ . '/../assets/schema.php';
     } else {

--- a/admin/includes/options.php
+++ b/admin/includes/options.php
@@ -4,19 +4,23 @@ use Sprint\Migration\Locale;
 use Sprint\Migration\Module;
 use Sprint\Migration\Out;
 use Sprint\Migration\VersionConfig;
+use Bitrix\Main\Application;
 
-if ($_SERVER['REQUEST_METHOD'] == "POST" && check_bitrix_sessid()) {
+$request = Application::getInstance()->getContext()->getRequest();
+$requestArray = $request->getPostList()->toArray() + $request->getQueryList()->toArray();
 
-    if (!empty($_REQUEST["options_remove"])) {
+if ($request->isPost() && check_bitrix_sessid()) {
+
+    if (!empty($requestArray["options_remove"])) {
         Module::removeDbOptions();
         Out::outSuccess(
             Locale::getMessage('OPTIONS_REMOVE_success')
         );
     }
 
-    if (!empty($_REQUEST["configuration_remove"])) {
+    if (!empty($requestArray["configuration_remove"])) {
         $versionConfig = new VersionConfig();
-        if ($versionConfig->deleteConfig($_REQUEST['configuration_name'])) {
+        if ($versionConfig->deleteConfig($requestArray['configuration_name'])) {
             Out::outSuccess(
                 Locale::getMessage('BUILDER_Cleaner_success')
             );
@@ -27,9 +31,9 @@ if ($_SERVER['REQUEST_METHOD'] == "POST" && check_bitrix_sessid()) {
         }
     }
 
-    if (!empty($_REQUEST["configuration_create"])) {
+    if (!empty($requestArray["configuration_create"])) {
         $versionConfig = new VersionConfig();
-        if ($versionConfig->createConfig($_REQUEST['configuration_name'])) {
+        if ($versionConfig->createConfig($requestArray['configuration_name'])) {
             Out::outSuccess(
                 Locale::getMessage('BUILDER_Configurator_success')
             );
@@ -40,7 +44,7 @@ if ($_SERVER['REQUEST_METHOD'] == "POST" && check_bitrix_sessid()) {
         }
     }
 
-    if (!empty($_REQUEST["gadgets_install"])) {
+    if (!empty($requestArray["gadgets_install"])) {
         /** @var $tmpmodule sprint_migration */
         $tmpmodule = CModule::CreateModuleObject('sprint.migration');
         $tmpmodule->installGadgets();

--- a/admin/steps/migration_create.php
+++ b/admin/steps/migration_create.php
@@ -2,19 +2,24 @@
 
 use Sprint\Migration\VersionConfig;
 use Sprint\Migration\VersionManager;
+use Bitrix\Main\Application;
+
 
 if (!defined("B_PROLOG_INCLUDED") || B_PROLOG_INCLUDED !== true) {
     die();
 }
 
-if ($_POST["step_code"] == "migration_create" && check_bitrix_sessid('send_sessid')) {
+$request = Application::getInstance()->getContext()->getRequest();
+
+
+if ($request->getPost('step_code') == "migration_create" && check_bitrix_sessid('send_sessid')) {
 
     /** @var $versionConfig VersionConfig */
     $versionManager = new VersionManager($versionConfig);
 
-    $builderName = !empty($_POST['builder_name']) ? trim($_POST['builder_name']) : '';
+    $builderName = !empty($request->getPost('builder_name')) ? trim($request->getPost('builder_name')) : '';
 
-    $builder = $versionManager->createBuilder($builderName, $_POST);
+    $builder = $versionManager->createBuilder($builderName, $request->getPostList()->toArray());
 
     if ($builder) {
 

--- a/admin/steps/migration_delete.php
+++ b/admin/steps/migration_delete.php
@@ -2,13 +2,17 @@
 
 use Sprint\Migration\VersionConfig;
 use Sprint\Migration\VersionManager;
+use Bitrix\Main\Application;
+
 
 if (!defined("B_PROLOG_INCLUDED") || B_PROLOG_INCLUDED !== true) {
     die();
 }
+$request = Application::getInstance()->getContext()->getRequest();
+
 
 $existsEvents = (
-($_POST["step_code"] == "migration_delete")
+($request->getPost('step_code') == "migration_delete")
 );
 
 if ($existsEvents && check_bitrix_sessid('send_sessid')) {
@@ -16,7 +20,7 @@ if ($existsEvents && check_bitrix_sessid('send_sessid')) {
     /** @var $versionConfig VersionConfig */
     $versionManager = new VersionManager($versionConfig);
 
-    $version = !empty($_POST['version']) ? $_POST['version'] : '';
+    $version = !empty($request->getPost('version')) ? $request->getPost('version') : '';
 
     $deleteresult = $versionManager->deleteMigration($version);
     Sprint\Migration\Out::outMessages($deleteresult);

--- a/admin/steps/migration_execute.php
+++ b/admin/steps/migration_execute.php
@@ -3,30 +3,31 @@
 use Sprint\Migration\Enum\VersionEnum;
 use Sprint\Migration\VersionConfig;
 use Sprint\Migration\VersionManager;
+use Bitrix\Main\Application;
 
 if (!defined("B_PROLOG_INCLUDED") || B_PROLOG_INCLUDED !== true) {
     die();
 }
+$request = Application::getInstance()->getContext()->getRequest();
 
-
-if ($_POST["step_code"] == "migration_execute" && check_bitrix_sessid('send_sessid')) {
+if ($request->getPost('step_code') == "migration_execute" && check_bitrix_sessid('send_sessid')) {
 
     /** @var $versionConfig VersionConfig */
     $versionManager = new VersionManager($versionConfig);
 
-    $params = !empty($_POST['params']) ? $_POST['params'] : [];
-    $restart = !empty($_POST['restart']) ? 1 : 0;
-    $version = isset($_POST['version']) ? $_POST['version'] : 0;
-    $action = !empty($_POST['action']) ? $_POST['action'] : 0;
-    $nextAction = !empty($_POST['next_action']) ? $_POST['next_action'] : 0;
-    $skipVersions = !empty($_POST['skip_versions']) ? $_POST['skip_versions'] : [];
-    $settag = !empty($_POST['settag']) ? trim($_POST['settag']) : '';
+    $params = !empty($request->getPost('params')) ? $request->getPost('params') : [];
+    $restart = !empty($request->getPost('restart')) ? 1 : 0;
+    $version = $request->getPost('version') != null ? $request->getPost('version') : 0;
+    $action = !empty($request->getPost('action')) ? $request->getPost('action') : 0;
+    $nextAction = !empty($request->getPost('next_action')) ? $request->getPost('next_action') : 0;
+    $skipVersions = !empty($request->getPost('skip_versions')) ? $request->getPost('skip_versions') : [];
+    $settag = !empty($request->getPost('settag')) ? trim($request->getPost('settag')) : '';
 
 
-    $search = !empty($_POST['search']) ? trim($_POST['search']) : '';
+    $search = !empty($request->getPost('search')) ? trim($request->getPost('search')) : '';
     $search = Sprint\Migration\Locale::convertToUtf8IfNeed($search);
 
-    $filter = !empty($_POST['filter']) ? trim($_POST['filter']) : '';
+    $filter = !empty($request->getPost('filter')) ? trim($request->getPost('filter')) : '';
 
     $filterVersion = [
         'search' => $search,

--- a/admin/steps/migration_list.php
+++ b/admin/steps/migration_list.php
@@ -6,18 +6,22 @@ use Sprint\Migration\Module;
 use Sprint\Migration\Out;
 use Sprint\Migration\VersionConfig;
 use Sprint\Migration\VersionManager;
+use Bitrix\Main\Application;
+
 
 if (!defined("B_PROLOG_INCLUDED") || B_PROLOG_INCLUDED !== true) {
     die();
 }
+$request = Application::getInstance()->getContext()->getRequest();
+
 
 $listView = (
-    ($_POST["step_code"] == "migration_view_all") ||
-    ($_POST["step_code"] == "migration_view_new") ||
-    ($_POST["step_code"] == "migration_view_tag") ||
-    ($_POST["step_code"] == "migration_view_modified") ||
-    ($_POST["step_code"] == "migration_view_older") ||
-    ($_POST["step_code"] == "migration_view_installed")
+    ($request->getPost('step_code') == "migration_view_all") ||
+    ($request->getPost('step_code') == "migration_view_new") ||
+    ($request->getPost('step_code') == "migration_view_tag") ||
+    ($request->getPost('step_code') == "migration_view_modified") ||
+    ($request->getPost('step_code') == "migration_view_older") ||
+    ($request->getPost('step_code') == "migration_view_installed")
 );
 
 if ($listView && check_bitrix_sessid('send_sessid')) {
@@ -25,29 +29,29 @@ if ($listView && check_bitrix_sessid('send_sessid')) {
     /** @var $versionConfig VersionConfig */
     $versionManager = new VersionManager($versionConfig);
 
-    $search = !empty($_POST['search']) ? trim($_POST['search']) : '';
+    $search = !empty($request->getPost('search')) ? trim($request->getPost('search')) : '';
     $search = Sprint\Migration\Locale::convertToUtf8IfNeed($search);
 
-    if ($_POST["step_code"] == "migration_view_new") {
+    if ($request->getPost('step_code') == "migration_view_new") {
         $versions = $versionManager->getVersions([
             'status' => VersionEnum::STATUS_NEW,
             'search' => $search,
         ]);
-    } elseif ($_POST["step_code"] == "migration_view_installed") {
+    } elseif ($request->getPost('step_code') == "migration_view_installed") {
         $versions = $versionManager->getVersions([
             'status' => VersionEnum::STATUS_INSTALLED,
             'search' => $search,
         ]);
-    } elseif ($_POST["step_code"] == "migration_view_tag") {
+    } elseif ($request->getPost('step_code') == "migration_view_tag") {
         $versions = $versionManager->getVersions([
             'tag' => $search,
         ]);
-    } elseif ($_POST["step_code"] == "migration_view_modified") {
+    } elseif ($request->getPost('step_code') == "migration_view_modified") {
         $versions = $versionManager->getVersions([
             'search' => $search,
             'modified' => 1,
         ]);
-    } elseif ($_POST["step_code"] == "migration_view_older") {
+    } elseif ($request->getPost('step_code') == "migration_view_older") {
         $versions = $versionManager->getVersions([
             'search' => $search,
             'older' => 1,

--- a/admin/steps/migration_mark.php
+++ b/admin/steps/migration_mark.php
@@ -2,22 +2,23 @@
 
 use Sprint\Migration\VersionConfig;
 use Sprint\Migration\VersionManager;
+use Bitrix\Main\Application;
+
 
 if (!defined("B_PROLOG_INCLUDED") || B_PROLOG_INCLUDED !== true) {
     die();
 }
 
 $existsEvents = (
-($_POST["step_code"] == "migration_mark")
+($request->getPost('step_code') == "migration_mark")
 );
 
 if ($existsEvents && check_bitrix_sessid('send_sessid')) {
-
     /** @var $versionConfig VersionConfig */
     $versionManager = new VersionManager($versionConfig);
 
-    $version = !empty($_POST['version']) ? $_POST['version'] : '';
-    $status = !empty($_POST['status']) ? $_POST['status'] : '';
+    $version = !empty($request->getPost('version')) ? $request->getPost('version') : '';
+    $status = !empty($request->getPost('status')) ? $request->getPost('status') : '';
 
     $markresult = $versionManager->markMigration($version, $status);
     Sprint\Migration\Out::outMessages($markresult);

--- a/admin/steps/migration_settag.php
+++ b/admin/steps/migration_settag.php
@@ -2,22 +2,25 @@
 
 use Sprint\Migration\VersionConfig;
 use Sprint\Migration\VersionManager;
+use Bitrix\Main\Application;
+
 
 if (!defined("B_PROLOG_INCLUDED") || B_PROLOG_INCLUDED !== true) {
     die();
 }
+$request = Application::getInstance()->getContext()->getRequest();
+
 
 $existsEvents = (
-($_POST["step_code"] == "migration_settag")
+($request->getPost('step_code') == "migration_settag")
 );
 
 if ($existsEvents && check_bitrix_sessid('send_sessid')) {
-
     /** @var $versionConfig VersionConfig */
     $versionManager = new VersionManager($versionConfig);
 
-    $version = !empty($_POST['version']) ? $_POST['version'] : '';
-    $settag = !empty($_POST['settag']) ? $_POST['settag'] : '';
+    $version = !empty($request->getPost('version')) ? $request->getPost('version') : '';
+    $settag = !empty($request->getPost('settag')) ? $request->getPost('settag') : '';
 
     $settagresult = $versionManager->setMigrationTag($version, $settag);
     Sprint\Migration\Out::outMessages($settagresult);

--- a/admin/steps/migration_status.php
+++ b/admin/steps/migration_status.php
@@ -4,17 +4,21 @@ use Sprint\Migration\Enum\VersionEnum;
 use Sprint\Migration\Locale;
 use Sprint\Migration\VersionConfig;
 use Sprint\Migration\VersionManager;
+use Bitrix\Main\Application;
+
 
 if (!defined("B_PROLOG_INCLUDED") || B_PROLOG_INCLUDED !== true) {
     die();
 }
+$request = Application::getInstance()->getContext()->getRequest();
 
-if ($_POST["step_code"] == "migration_view_status" && check_bitrix_sessid('send_sessid')) {
+
+if ($request->getPost('step_code') == "migration_view_status" && check_bitrix_sessid('send_sessid')) {
 
     /** @var $versionConfig VersionConfig */
     $versionManager = new VersionManager($versionConfig);
 
-    $search = !empty($_POST['search']) ? trim($_POST['search']) : '';
+    $search = !empty($request->getPost('search')) ? trim($request->getPost('search')) : '';
     $search = Locale::convertToUtf8IfNeed($search);
 
     $versions = $versionManager->getVersions([

--- a/admin/steps/migration_transfer.php
+++ b/admin/steps/migration_transfer.php
@@ -2,19 +2,23 @@
 
 use Sprint\Migration\VersionConfig;
 use Sprint\Migration\VersionManager;
+use Bitrix\Main\Application;
+
 
 if (!defined("B_PROLOG_INCLUDED") || B_PROLOG_INCLUDED !== true) {
     die();
 }
+$request = Application::getInstance()->getContext()->getRequest();
+
 
 $existsEvents = (
-($_POST["step_code"] == "migration_transfer")
+($request->getPost('step_code') == "migration_transfer")
 );
 
 if ($existsEvents && check_bitrix_sessid('send_sessid')) {
 
-    $version = !empty($_POST['version']) ? $_POST['version'] : '';
-    $transferTo = !empty($_POST['transfer_to']) ? $_POST['transfer_to'] : '';
+    $version = !empty($request->getPost('version')) ? $request->getPost('version') : '';
+    $transferTo = !empty($request->getPost('transfer_to')) ? $request->getPost('transfer_to') : '';
 
     /** @var $versionConfig VersionConfig */
     $vmFrom = new VersionManager($versionConfig);

--- a/admin/steps/schema_export.php
+++ b/admin/steps/schema_export.php
@@ -4,15 +4,19 @@ use Sprint\Migration\Exceptions\RestartException;
 use Sprint\Migration\Out;
 use Sprint\Migration\SchemaManager;
 use Sprint\Migration\VersionConfig;
+use Bitrix\Main\Application;
+
 
 if (!defined("B_PROLOG_INCLUDED") || B_PROLOG_INCLUDED !== true) {
     die();
 }
+$request = Application::getInstance()->getContext()->getRequest();
 
-if ($_POST["step_code"] == "schema_export" && check_bitrix_sessid('send_sessid')) {
 
-    $params = !empty($_POST['params']) ? $_POST['params'] : [];
-    $checked = !empty($_POST['schema_checked']) ? $_POST['schema_checked'] : [];
+if ($request->getPost('step_code') == "schema_export" && check_bitrix_sessid('send_sessid')) {
+
+    $params = !empty($request->getPost('params')) ? $request->getPost('params') : [];
+    $checked = !empty($request->getPost('schema_checked')) ? $request->getPost('schema_checked') : [];
 
 
     /** @var $versionConfig VersionConfig */

--- a/admin/steps/schema_import.php
+++ b/admin/steps/schema_import.php
@@ -4,20 +4,22 @@ use Sprint\Migration\Exceptions\RestartException;
 use Sprint\Migration\Out;
 use Sprint\Migration\SchemaManager;
 use Sprint\Migration\VersionConfig;
+use Bitrix\Main\Application;
+
 
 if (!defined('B_PROLOG_INCLUDED') || B_PROLOG_INCLUDED !== true) {
     die();
 }
-
+$request = Application::getInstance()->getContext()->getRequest();
 $hasSteps = (
-    ($_POST['step_code'] == 'schema_import') ||
-    ($_POST['step_code'] == 'schema_test')
+    ($request->getPost('step_code') == 'schema_import') ||
+    ($request->getPost('step_code') == 'schema_test')
 );
 
 if ($hasSteps && check_bitrix_sessid('send_sessid')) {
-    $params = !empty($_POST['params']) ? $_POST['params'] : [];
-    $checked = !empty($_POST['schema_checked']) ? $_POST['schema_checked'] : [];
-    $stepCode = !empty($_POST['step_code']) ? $_POST['step_code'] : '';
+    $params = !empty($request->getPost('params')) ? $request->getPost('params') : [];
+    $checked = !empty($request->getPost('schema_checked')) ? $request->getPost('schema_checked') : [];
+    $stepCode = !empty($request->getPost('step_code')) ? $request->getPost('step_code') : '';
 
     /** @var $versionConfig VersionConfig */
     $schemaManager = new SchemaManager($versionConfig, $params);

--- a/admin/steps/schema_list.php
+++ b/admin/steps/schema_list.php
@@ -3,12 +3,16 @@
 use Sprint\Migration\Locale;
 use Sprint\Migration\SchemaManager;
 use Sprint\Migration\VersionConfig;
+use Bitrix\Main\Application;
+
 
 if (!defined("B_PROLOG_INCLUDED") || B_PROLOG_INCLUDED !== true) {
     die();
 }
+$request = Application::getInstance()->getContext()->getRequest();
 
-if ($_POST["step_code"] == "schema_list" && check_bitrix_sessid('send_sessid')) {
+
+if ($request->getPost('step_code') == "schema_list" && check_bitrix_sessid('send_sessid')) {
     /** @var $versionConfig VersionConfig */
     $schemaManager = new SchemaManager($versionConfig);
 
@@ -19,7 +23,7 @@ if ($_POST["step_code"] == "schema_list" && check_bitrix_sessid('send_sessid')) 
 //        $defaultSchemas[] = $schema->getName();
 //    }
 
-    $schemaChecked = isset($_POST['schema_checked']) ? (array)$_POST['schema_checked'] : $defaultSchemas;
+    $schemaChecked = $request->getPost('schema_checked') != null ? (array)$request->getPost('schema_checked') : $defaultSchemas;
 
     ?>
     <table class="sp-list">


### PR DESCRIPTION
Избавился от суперглобальных переменных `$_POST` и `$_REQUEST`
Сделано это чтобы избавиться от ошибок в сканере безопасности, часто клиенту "мозолит" глаза эта ошибка 

![image](https://user-images.githubusercontent.com/20552473/88921096-595e6d80-d287-11ea-825a-67d97c22c1bc.png)


