### PR TITLE
Исправлен вывод ошибок при ненайденном файле миграции

### DIFF
--- a/lib/versionmanager.php
+++ b/lib/versionmanager.php
@@ -83,6 +83,14 @@ class VersionManager
 
             $meta = $this->getVersionByName($versionName);
 
+            if (!$meta || empty($meta['class'])) {
+                throw new MigrationException('failed to initialize migration');
+            }
+
+            if ($meta['older']) {
+                throw new MigrationException('unsupported version ' . $meta['older']);
+            }
+
             if (!$force) {
                 if ($action == VersionEnum::ACTION_UP && $meta['status'] != VersionEnum::STATUS_NEW) {
                     throw new MigrationException('migration already up');
@@ -91,14 +99,6 @@ class VersionManager
                 if ($action == VersionEnum::ACTION_DOWN && $meta['status'] != VersionEnum::STATUS_INSTALLED) {
                     throw new MigrationException('migration already down');
                 }
-            }
-
-            if (!$meta || empty($meta['class'])) {
-                throw new MigrationException('failed to initialize migration');
-            }
-
-            if ($meta['older']) {
-                throw new MigrationException('unsupported version ' . $meta['older']);
             }
 
             /** @var $versionInstance Version */


### PR DESCRIPTION
При работе через консоль, если допустил ошибку в названии версии, или если файл не найден, выводилось сообщение, что миграция уже установлена. Поменял проверочки местами, чтобы выводилась верная ошибка.

![photo_2020-09-03_19-17-39](https://user-images.githubusercontent.com/25615454/92222391-01cba700-eeb0-11ea-83f6-efabca0fdeb9.jpg)
