### PR TITLE
correct value length

### DIFF
--- a/lib/abstractexchange.php
+++ b/lib/abstractexchange.php
@@ -129,10 +129,18 @@ abstract class AbstractExchange
         }
     }
 
+    protected function correctSerializeValueLength($value)
+    {
+        $htmlCodedLength = strlen($value['TEXT']);
+        $htmlDecodedLength = strlen(htmlspecialchars_decode($value['TEXT']));
+        return str_replace($htmlCodedLength, $htmlDecodedLength, serialize($value));
+    }
+
     protected function writeSerializedValue($writer, $value)
     {
         if (is_array($value)) {
-            $this->writeSingleValue($writer, serialize($value), ['type' => 'serialized']);
+            $serializedValue = $this->correctSerializeValueLength($value);
+            $this->writeSingleValue($writer, $serializedValue, ['type' => 'serialized']);
         } else {
             $this->writeSingleValue($writer, $value);
         }

--- a/lib/abstractexchange.php
+++ b/lib/abstractexchange.php
@@ -129,17 +129,17 @@ abstract class AbstractExchange
         }
     }
 
-    protected function correctSerializeValueLength($value)
+    protected function correctSerializeValue($value)
     {
-        $htmlCodedLength = strlen($value['TEXT']);
-        $htmlDecodedLength = strlen(htmlspecialchars_decode($value['TEXT']));
-        return str_replace($htmlCodedLength, $htmlDecodedLength, serialize($value));
+        $htmlCodedSubstring = 's:' . strlen($value['TEXT']) . ':"';
+        $htmlDecodedSubstring= 's:' . strlen(htmlspecialchars_decode($value['TEXT'])) . ':"';
+        return str_replace($htmlCodedSubstring, $htmlDecodedSubstring, serialize($value));
     }
 
     protected function writeSerializedValue($writer, $value)
     {
         if (is_array($value)) {
-            $serializedValue = $this->correctSerializeValueLength($value);
+            $serializedValue = $this->correctSerializeValue($value);
             $this->writeSingleValue($writer, $serializedValue, ['type' => 'serialized']);
         } else {
             $this->writeSingleValue($writer, $value);


### PR DESCRIPTION
При экспорте происходит преобразование спецсимволов и сериализация.
![coded-length](https://i.imgur.com/Hcj54Va.png)

При импорте происходит замена спецсимволов и десериализация, но не пересчитывается длина, из-за чего появляются ошибки.
![deleting-specialchars](https://i.imgur.com/t1uHDzb.png)
![decoded-length](https://i.imgur.com/ipv8QDR.png)

Добавил метод корректировки длины значения

