### PR TITLE
Исправляет E_WARNING при создании миграции переноса элементов ИБ

### DIFF
--- a/lib/exchange/iblockelementsexport.php
+++ b/lib/exchange/iblockelementsexport.php
@@ -121,7 +121,6 @@ class IblockElementsExport extends AbstractExchange
 
             foreach ($items as $item) {
                 $writer = new XMLWriter();
-                $writer->startDocument('1.0', 'UTF-8');
                 $writer->openMemory();
                 $writer->startElement('item');
 


### PR DESCRIPTION
`startDocument` до открытия документа вызывает `XMLWriter::startDocument(): Invalid or uninitialized XMLWriter object`.

PS: он не требуется, т.к. выше уже был `$this->appendToExchangeFile('<?xml version="1.0" encoding="UTF-8"?>');`