### PR TITLE
fix: совместимость в PHP 8.0

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -13,7 +13,7 @@ class sprint_migration extends CModule
     var $PARTNER_URI;
     var $MODULE_GROUP_RIGHTS = "Y";
 
-    function sprint_migration()
+    public function __constructor()
     {
         $arModuleVersion = [];
 


### PR DESCRIPTION
В админке в списке настроек модулей теперь корректно выводится название модуля (вместо пустого места)
Было так: https://pasteboard.co/ztgX0zEJy9sM.png 
Стало так: https://pasteboard.co/NiDrRzpAS3OM.png 