### PR TITLE
Фикс типов возвращаемых значений в аннотации миграций

### DIFF
--- a/lib/version.php
+++ b/lib/version.php
@@ -35,7 +35,7 @@ class Version extends ExchangeEntity
      *
      * @throws RestartException
      * @throws HelperException
-     * @return bool
+     * @return bool|void
      */
     public function up()
     {
@@ -47,7 +47,7 @@ class Version extends ExchangeEntity
      *
      * @throws RestartException
      * @throws HelperException
-     * @return bool
+     * @return bool|void
      */
     public function down()
     {


### PR DESCRIPTION
Чтобы PHPStan не сходил с ума
![image](https://user-images.githubusercontent.com/33313896/211189435-dc4ba53b-165b-45fe-a1dd-9403b6b823ee.png)

Т.к. в [стабах ](https://github.com/andreyryabin/sprint.migration/blob/master/templates/AgentExport.php)создается именно с @return bool|void 