### PR TITLE
Исправил опечатку в versionconfig.php

### DIFF
--- a/lib/versionconfig.php
+++ b/lib/versionconfig.php
@@ -295,7 +295,7 @@ class VersionConfig
             $values['version_builders'] = VersionConfig::getDefaultBuilders();
         }
 
-        if (!empty($values['version_schemas']) || !is_array($values['version_schemas'])) {
+        if (empty($values['version_schemas']) || !is_array($values['version_schemas'])) {
             $values['version_schemas'] = VersionConfig::getDefaultSchemas();
         }
 


### PR DESCRIPTION
У меня в логи ошибок падает сообщение E_WARNING:

```
Undefined array key "version_schemas" (0)
...\local\modules\sprint.migration\lib\versionconfig.php:298
```

Судя по всему, здесь опечатка просто.