### PR TITLE
fix: Предупреждение в PHP 8

### DIFF
--- a/lib/versionconfig.php
+++ b/lib/versionconfig.php
@@ -95,7 +95,7 @@ class VersionConfig
 
         uasort(
             $this->configList, function ($a, $b) {
-            return ($a['sort'] >= $b['sort']);
+            return ($a['sort'] <=> $b['sort']);
         }
         );
 


### PR DESCRIPTION
Исправлен deprecation warning в PHP 8: 
uasort(): Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero

Порядок сортировки остался такой же, как был.