### PR TITLE
Фикс типов в iblockexchangehelper.php

### DIFF
--- a/lib/helpers/iblockexchangehelper.php
+++ b/lib/helpers/iblockexchangehelper.php
@@ -156,7 +156,7 @@ class IblockExchangeHelper extends IblockHelper implements ReaderHelperInterface
     /**
      * @throws HelperException
      */
-    public function getSectionUniqNamesByIds(int $iblockId, int|array $sectionIds): array
+    public function getSectionUniqNamesByIds(int $iblockId, $sectionIds): array
     {
         $sectionIds = array_filter(is_array($sectionIds) ? $sectionIds : [$sectionIds]);
 
@@ -171,7 +171,7 @@ class IblockExchangeHelper extends IblockHelper implements ReaderHelperInterface
     /**
      * @throws HelperException
      */
-    public function getElementUniqNamesByIds(int $iblockId, int|array $elementIds): array
+    public function getElementUniqNamesByIds(int $iblockId, $elementIds): array
     {
         $elementIds = array_filter(is_array($elementIds) ? $elementIds : [$elementIds]);
 


### PR DESCRIPTION
Если связь пустая - прилетает '' но никак не int|array