### PR TITLE
Добавил поддержку Bitrix CLI

### DIFF
--- a/.settings.php
+++ b/.settings.php
@@ -1,10 +1,20 @@
 <?php
 
+use Sprint\Migration\SymfonyBundle\Command\ConsoleCommand;
+
 return [
     'controllers' => [
         'value' => [
             'defaultNamespace' => '\\Sprint\\Migration\\Controller',
         ],
         'readonly' => true,
-    ]
+    ],
+    'console' => [
+        'value' => [
+            'commands' => [
+                ConsoleCommand::class,
+            ],
+        ],
+        'readonly' => true,
+    ],
 ];


### PR DESCRIPTION
В документации есть [пример](https://github.com/andreyryabin/sprint.migration/wiki#%D0%BA%D0%BE%D0%BD%D1%81%D0%BE%D0%BB%D1%8C) использования консольных команд. У битрикса есть так называемый [Bitrix CLI](https://dev.1c-bitrix.ru/learning/course/index.php?COURSE_ID=43&LESSON_ID=11685&LESSON_PATH=3913.3516.4776.2483.11685). Посчитал, что было бы не плохо иметь возможность пользования консольными командами из Bitrix CLI.