### PR TITLE
Поднял версию composer/installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "andreyryabin/sprint.migration",
   "description": "bitrix migration module",
   "homepage": "https://marketplace.1c-bitrix.ru/solutions/sprint.migration/",
-  "type": "bitrix-d7-module",
+  "type": "bitrix-module",
   "keywords": [
     "bitrix",
     "sprint",
@@ -24,10 +24,5 @@
     "ext-json": "*",
     "ext-xmlreader": "*",
     "ext-xmlwriter": "*"
-  },
-  "config": {
-    "allow-plugins": {
-      "composer/installers": true
-    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "andreyryabin/sprint.migration",
   "description": "bitrix migration module",
   "homepage": "https://marketplace.1c-bitrix.ru/solutions/sprint.migration/",
-  "type": "bitrix-module",
+  "type": "bitrix-d7-module",
   "keywords": [
     "bitrix",
     "sprint",
@@ -20,9 +20,14 @@
   "license": "MIT",
   "require": {
     "php": ">=8.1",
-    "composer/installers": "~1",
+    "composer/installers": "^1.0|^2.0",
     "ext-json": "*",
     "ext-xmlreader": "*",
     "ext-xmlwriter": "*"
+  },
+  "config": {
+    "allow-plugins": {
+      "composer/installers": true
+    }
   }
 }


### PR DESCRIPTION
Некоторые модули/зависимости в моем проекте требуют composer/installer версии ^2.0. Поднял версию, заодно избавился от [deprecated](https://github.com/composer/installers/blob/main/src/Composer/Installers/BitrixInstaller.php) type пакета. 