### PR TITLE
Добавил rubric migration helper

### DIFF
--- a/lib/builders/subscribebuilder.php
+++ b/lib/builders/subscribebuilder.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Sprint\Migration\Builders;
+
+use Sprint\Migration\Exceptions\HelperException;
+use Sprint\Migration\Exceptions\MigrationException;
+use Sprint\Migration\Exceptions\RebuildException;
+use Sprint\Migration\Locale;
+use Sprint\Migration\Module;
+use Sprint\Migration\VersionBuilder;
+
+class SubscribeBuilder extends VersionBuilder
+{
+    protected function isBuilderEnabled()
+    {
+        return $this->getHelperManager()->Subscribe()->isEnabled();
+    }
+
+    protected function initialize()
+    {
+        $this->setTitle(Locale::getMessage('BUILDER_SubscribeExport1'));
+        $this->setGroup(Locale::getMessage('BUILDER_GROUP_Subscribe'));
+        $this->setDescription(Locale::getMessage('BUILDER_SubscribeExport_Info'));
+
+        $this->addVersionFields();
+    }
+
+    /**
+     * @throws MigrationException
+     * @throws RebuildException
+     * @throws HelperException
+     */
+    protected function execute()
+    {
+        $helper = $this->getHelperManager();
+
+        $rubricIds = $this->addFieldAndReturn('rubric_ids', [
+            'title'    => Locale::getMessage('BUILDER_SubscribeExport_rubric_ids'),
+            'width'    => 350,
+            'multiple' => 1,
+            'value'    => [],
+            'items'    => $this->getRubricsSelect(),
+        ]);
+
+        $items = $helper->Subscribe()->exportRubrics($rubricIds);
+
+        if (empty($items)) {
+            $this->rebuildField('rubric_ids');
+        }
+
+        $this->createVersionFile(
+            Module::getModuleTemplateFile('SubscribeExport'),
+            [
+                'items' => $items,
+            ]
+        );
+    }
+
+    protected function getRubricsSelect(): array
+    {
+        $items = $this->getHelperManager()->Subscribe()->getRubrics();
+
+        $items = array_filter($items, fn($item) => !empty($item['CODE']));
+
+        $items = array_map(function ($item) {
+            $item['TITLE'] = '[' . $item['CODE'] . '] ' . $item['NAME'];
+            return $item;
+        }, $items);
+
+        return $this->createSelectWithGroups($items, 'ID', 'TITLE', 'LID');
+    }
+}

--- a/lib/helpermanager.php
+++ b/lib/helpermanager.php
@@ -18,6 +18,7 @@ use Sprint\Migration\Helpers\OptionHelper;
 use Sprint\Migration\Helpers\OrderPropertiesHelper;
 use Sprint\Migration\Helpers\SiteHelper;
 use Sprint\Migration\Helpers\SqlHelper;
+use Sprint\Migration\Helpers\SubscribeHelper;
 use Sprint\Migration\Helpers\TaskHelper;
 use Sprint\Migration\Helpers\TextHelper;
 use Sprint\Migration\Helpers\UserGroupHelper;
@@ -41,6 +42,7 @@ use Sprint\Migration\Helpers\UserTypeEntityHelper;
  * @method FormHelper               Form()
  * @method DeliveryServiceHelper    DeliveryService()
  * @method SqlHelper                Sql()
+ * @method SubscribeHelper          Subscribe()
  * @method MedialibHelper           Medialib()
  * @method TextHelper               Text()
  * @method IblockExchangeHelper     IblockExchange()

--- a/lib/helpers/subscribehelper.php
+++ b/lib/helpers/subscribehelper.php
@@ -1,0 +1,233 @@
+<?php
+
+namespace Sprint\Migration\Helpers;
+
+use CRubric;
+use CAgent;
+use COption;
+use Sprint\Migration\Exceptions\HelperException;
+use Sprint\Migration\Helper;
+use Sprint\Migration\Locale;
+
+class SubscribeHelper extends Helper
+{
+    public function isEnabled(): bool
+    {
+        return $this->checkModules(['subscribe']);
+    }
+
+    public function getRubrics(array $filter = []): array
+    {
+        $dbres = CRubric::GetList(
+            [
+                'LID'  => 'ASC',
+                'SORT' => 'ASC',
+                'NAME' => 'ASC',
+                'ID'   => 'ASC',
+            ],
+            $filter
+        );
+
+        return $this->fetchAll($dbres);
+    }
+
+    public function getRubricById(int $rubricId): bool|array
+    {
+        return CRubric::GetByID($rubricId)->Fetch();
+    }
+
+    public function getRubricId(string $lid, string $code): int
+    {
+        if (empty($lid) || empty($code)) {
+            return 0;
+        }
+
+        $item = CRubric::GetList(
+            ['ID' => 'ASC'],
+            [
+                'LID'  => $lid,
+                'CODE' => $code,
+            ]
+        )->Fetch();
+
+        return (int)($item['ID'] ?? 0);
+    }
+
+    /**
+     * @throws HelperException
+     */
+    public function exportRubricById(int $rubricId): array
+    {
+        $item = $this->getRubricById($rubricId);
+
+        if (!empty($item)) {
+            return $this->prepareExportRubric($item);
+        }
+
+        throw new HelperException("Subscribe rubric with ID=$rubricId not found");
+    }
+
+    /**
+     * @throws HelperException
+     */
+    public function exportRubrics(array $rubricIds): array
+    {
+        return array_map(
+            fn($rubricId) => $this->exportRubricById($rubricId),
+            $this->makeNonEmptyArray($rubricIds)
+        );
+    }
+
+    /**
+     * @throws HelperException
+     */
+    public function saveRubric(array $fields): int
+    {
+        $this->checkRequiredKeys($fields, ['LID', 'CODE', 'NAME']);
+
+        $fields = $this->prepareRubricFields($fields);
+        $rubricId = $this->getRubricId($fields['LID'], $fields['CODE']);
+
+        if (!$rubricId) {
+            return $this->addRubric($fields);
+        }
+
+        $exists = $this->prepareExportRubric($this->getRubricById($rubricId));
+        if ($this->checkDiff($exists, $this->prepareExportRubric($fields))) {
+            return $this->updateRubric($rubricId, $fields);
+        }
+
+        return $rubricId;
+    }
+
+    /**
+     * @throws HelperException
+     */
+    public function addRubric(array $fields): int
+    {
+        $this->checkRequiredKeys($fields, ['LID', 'CODE', 'NAME']);
+
+        $rubric = new CRubric();
+        $fields = $this->prepareRubricFieldsForSave($fields);
+        $this->preparePostingTemplateAgent($fields);
+        $rubricId = $rubric->Add($fields);
+
+        if ($rubricId) {
+            $this->outNotice(Locale::getMessage('SUBSCRIBE_RUBRIC_UPDATED', ['#NAME#' => $fields['NAME']]));
+            return (int)$rubricId;
+        }
+
+        $this->throwApplicationExceptionIfExists();
+        throw new HelperException($rubric->LAST_ERROR ?: "Subscribe rubric \"{$fields['NAME']}\" not added");
+    }
+
+    /**
+     * @throws HelperException
+     */
+    public function updateRubric(int $rubricId, array $fields): int
+    {
+        $this->checkRequiredKeys($fields, ['LID', 'CODE', 'NAME']);
+
+        $rubric = new CRubric();
+        $fields = $this->prepareRubricFieldsForSave($fields);
+        $this->preparePostingTemplateAgent($fields);
+        $result = $rubric->Update($rubricId, $fields);
+
+        if ($result) {
+            $this->outNotice(Locale::getMessage('SUBSCRIBE_RUBRIC_UPDATED', ['#NAME#' => $fields['NAME']]));
+            return $rubricId;
+        }
+
+        $this->throwApplicationExceptionIfExists();
+        throw new HelperException($rubric->LAST_ERROR ?: "Subscribe rubric \"{$fields['NAME']}\" not updated");
+    }
+
+    public function deleteRubric(int $rubricId): bool
+    {
+        return (bool)CRubric::Delete($rubricId);
+    }
+
+    public function deleteRubricIfExists(string $lid, string $code): bool
+    {
+        $rubricId = $this->getRubricId($lid, $code);
+        if (!$rubricId) {
+            return false;
+        }
+
+        return $this->deleteRubric($rubricId);
+    }
+
+    protected function prepareExportRubric(array $item): array
+    {
+        $this->checkRequiredKeys($item, ['LID', 'CODE', 'NAME']);
+
+        $item = $this->prepareRubricFields($item);
+
+        $this->unsetKeys($item, [
+            'ID',
+            'LAST_EXECUTED',
+        ]);
+
+        return $item;
+    }
+
+    protected function preparePostingTemplateAgent(array $item): void
+    {
+        if (
+            ($item['ACTIVE'] ?? '') === 'Y'
+            && ($item['AUTO'] ?? '') === 'Y'
+            && COption::GetOptionString('subscribe', 'subscribe_template_method') !== 'cron'
+        ) {
+            CAgent::RemoveAgent('CPostingTemplate::Execute();', 'subscribe');
+        }
+    }
+
+    protected function prepareRubricFieldsForSave(array $item): array
+    {
+        $item = $this->prepareRubricFields($item);
+
+        if (($item['AUTO'] ?? '') === 'Y' && empty($item['LAST_EXECUTED'])) {
+            $item['LAST_EXECUTED'] = ConvertTimeStamp(time(), 'FULL');
+        }
+
+        return $item;
+    }
+
+    protected function prepareRubricFields(array $item): array
+    {
+        $default = [
+            'DESCRIPTION'   => '',
+            'SORT'          => 100,
+            'ACTIVE'        => 'Y',
+            'AUTO'          => 'N',
+            'DAYS_OF_MONTH' => '',
+            'DAYS_OF_WEEK'  => '',
+            'TIMES_OF_DAY'  => '',
+            'TEMPLATE'      => '',
+            'VISIBLE'       => 'Y',
+            'FROM_FIELD'    => '',
+        ];
+
+        $item = array_merge($default, $item);
+
+        return array_intersect_key(
+            $item,
+            array_flip([
+                'LID',
+                'CODE',
+                'NAME',
+                'DESCRIPTION',
+                'SORT',
+                'ACTIVE',
+                'AUTO',
+                'DAYS_OF_MONTH',
+                'DAYS_OF_WEEK',
+                'TIMES_OF_DAY',
+                'TEMPLATE',
+                'VISIBLE',
+                'FROM_FIELD',
+                'LAST_EXECUTED',
+            ])
+        );
+    }
+}

--- a/lib/versionconfig.php
+++ b/lib/versionconfig.php
@@ -18,6 +18,7 @@ use Sprint\Migration\Builders\MarkerBuilder;
 use Sprint\Migration\Builders\MedialibElementsBuilder;
 use Sprint\Migration\Builders\OptionBuilder;
 use Sprint\Migration\Builders\OrderPropertiesBuilder;
+use Sprint\Migration\Builders\SubscribeBuilder;
 use Sprint\Migration\Builders\TransferBuilder;
 use Sprint\Migration\Builders\UserGroupBuilder;
 use Sprint\Migration\Builders\UserOptionsBuilder;
@@ -272,6 +273,7 @@ class VersionConfig
             'OptionBuilder'           => OptionBuilder::class,
             'FormBuilder'             => FormBuilder::class,
             'EventBuilder'            => EventBuilder::class,
+            'SubscribeBuilder'        => SubscribeBuilder::class,
             'UserOptionsBuilder'      => UserOptionsBuilder::class,
             'OrderPropertiesBuilder'  => OrderPropertiesBuilder::class,
             'MedialibElementsBuilder' => MedialibElementsBuilder::class,

--- a/locale/en.php
+++ b/locale/en.php
@@ -73,6 +73,7 @@
         "WRITE_UP_CODE"            => "Write migration code in method up()",
         "WRITE_DOWN_CODE"          => "Write migration code in method down()",
         "LOADING_TEXT"             => "Loading...",
+        "SUBSCRIBE_RUBRIC_UPDATED" => "Subscription rubric #NAME# saved",
     ]
 );
 \Sprint\Migration\Locale::loadLocale(
@@ -110,6 +111,9 @@
         "BUILDER_TransferSelect"             => "Select migrations",
         "BUILDER_EventExport1"               => "Create migration for event types",
         "BUILDER_EventExport_event_types"    => "Select event types",
+        "BUILDER_SubscribeExport1"           => "Create migration for subscription rubrics",
+        "BUILDER_SubscribeExport_rubric_ids" => "Select subscription rubrics",
+        "BUILDER_SubscribeExport_Info"       => "Subscription rubric must have a symbolic code filled in",
         "BUILDER_AgentExport1"               => "Create migration for agents",
         "BUILDER_AgentExport2"               => "Set agent module and name (MODULE_ID, NAME), to see it in the list",
         "BUILDER_AgentExport_agent_id"       => "Select agents",
@@ -481,6 +485,7 @@
         "BUILDER_GROUP_Hlblock"  => "Highload information blocks",
         "BUILDER_GROUP_Sale"     => "Sale module",
         "BUILDER_GROUP_Form"     => "Web Forms",
+        "BUILDER_GROUP_Subscribe" => "Subscriptions",
         "BUILDER_GROUP_Medialib" => "Media Library",
         "BUILDER_GROUP_Tools"    => "Tools",
     ]

--- a/locale/ru.php
+++ b/locale/ru.php
@@ -73,6 +73,7 @@
         "WRITE_UP_CODE"            => "Укажите код установки миграции в методе up()",
         "WRITE_DOWN_CODE"          => "Укажите код отката миграции в методе down()",
         "LOADING_TEXT"             => "Загрузка...",
+        "SUBSCRIBE_RUBRIC_UPDATED" => "Рубрика подписки #NAME# сохранена",
     ]
 );
 \Sprint\Migration\Locale::loadLocale(
@@ -110,6 +111,9 @@
         "BUILDER_TransferSelect"             => "Выбрать миграции",
         "BUILDER_EventExport1"               => "Создать миграцию для почтовых событий",
         "BUILDER_EventExport_event_types"    => "Выберите типы почтовых событий",
+        "BUILDER_SubscribeExport1"           => "Создать миграцию для рубрик подписок",
+        "BUILDER_SubscribeExport_rubric_ids" => "Выберите рубрики подписок",
+        "BUILDER_SubscribeExport_Info"       => "У подписки должен быть заполнен Символьный код",
         "BUILDER_AgentExport1"               => "Создать миграцию для агентов",
         "BUILDER_AgentExport2"               => "Задайте модуль и функцию агента (MODULE_ID, NAME), чтобы увидеть его в списке",
         "BUILDER_AgentExport_agent_id"       => "Выберите агенты",
@@ -479,6 +483,7 @@
         "BUILDER_GROUP_Hlblock"  => "Highload-блоки",
         "BUILDER_GROUP_Sale"     => "Интернет-магазин",
         "BUILDER_GROUP_Form"     => "Веб-формы",
+        "BUILDER_GROUP_Subscribe" => "Подписки",
         "BUILDER_GROUP_Medialib" => "Медиабиблиотека",
         "BUILDER_GROUP_Tools"    => "Инструменты",
     ]

--- a/templates/SubscribeExport.php
+++ b/templates/SubscribeExport.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @var $version
+ * @var $description
+ * @var $items
+ * @var $extendUse
+ * @var $extendClass
+ * @var $moduleVersion
+ * @var $author
+ * @formatter:off
+ */
+
+?><?php echo "<?php\n" ?>
+
+namespace Sprint\Migration;
+
+<?php echo $extendUse ?>
+
+class <?php echo $version ?> extends <?php echo $extendClass ?>
+
+{
+    protected $author = "<?php echo $author ?>";
+
+    protected $description = "<?php echo $description ?>";
+
+    protected $moduleVersion = "<?php echo $moduleVersion ?>";
+
+    /**
+     * @throws Exceptions\HelperException
+     * @return bool|void
+     */
+    public function up()
+    {
+        $helper = $this->getHelperManager();
+<?php foreach ($items as $item) { ?>
+        $helper->Subscribe()->saveRubric(<?php echo var_export($item, 1) ?>);
+<?php } ?>
+    }
+}


### PR DESCRIPTION
Добавлена поддержка миграций рубрик подписок модуля `subscribe`.

  Что сделано:
  - добавлен `SubscribeHelper` для сохранения, обновления, удаления и экспорта рубрик подписок;
  - добавлен `SubscribeBuilder` для генерации миграции из админского builder-интерфейса;
  - добавлен шаблон `SubscribeExport`;
  - helper зарегистрирован в `HelperManager`;
  - builder добавлен в список стандартных builders;
  - добавлены ru/en подписи.

  Граница переноса:
  - переносятся только сами рубрики подписок из `b_list_rubric`;
  - подписчики не переносятся;
  - выпуски/постинги не переносятся;
  - связи подписчиков и выпусков с рубриками не переносятся.

  Ключ сопоставления рубрики:
  - используется строго `LID + CODE`;