### PR TITLE
Добавил forum migration helper

### DIFF
--- a/lib/builders/forumbuilder.php
+++ b/lib/builders/forumbuilder.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Sprint\Migration\Builders;
+
+use Sprint\Migration\Exceptions\HelperException;
+use Sprint\Migration\Exceptions\MigrationException;
+use Sprint\Migration\Exceptions\RebuildException;
+use Sprint\Migration\Locale;
+use Sprint\Migration\Module;
+use Sprint\Migration\VersionBuilder;
+
+class ForumBuilder extends VersionBuilder
+{
+    protected function isBuilderEnabled(): bool
+    {
+        return $this->getHelperManager()->Forum()->isEnabled();
+    }
+
+    protected function initialize()
+    {
+        $this->setGroup(Locale::getMessage('BUILDER_GROUP_Forum'));
+
+        $this->setTitle(implode(' ', [
+            Locale::getMessage('BUILDER_ForumExport1'),
+            Locale::getMessage('DEVELOPER_LABEL'),
+        ]));
+
+        $this->setDescription(implode(PHP_EOL, [
+            Locale::getMessage('DEVELOPER_NAME', ['#VALUE#' => '@temi4']),
+            Locale::getMessage('BUILDER_ForumExport_Info'),
+        ]));
+
+        $this->addVersionFields();
+    }
+
+    /**
+     * @throws HelperException
+     * @throws MigrationException
+     * @throws RebuildException
+     */
+    protected function execute()
+    {
+        $helper = $this->getHelperManager();
+
+        $forumIds = $this->addFieldAndReturn('forum_ids', [
+            'title'    => Locale::getMessage('BUILDER_ForumExport_forum_ids'),
+            'width'    => 350,
+            'multiple' => 1,
+            'value'    => [],
+            'items'    => $this->getForumsSelect(),
+        ]);
+
+        $forums = $helper->Forum()->exportForums($forumIds);
+
+        if (empty($forums)) {
+            $this->rebuildField('forum_ids');
+        }
+
+        $this->createVersionFile(
+            Module::getModuleTemplateFile('ForumExport'),
+            [
+                'groups' => [],
+                'forums' => $forums,
+            ]
+        );
+    }
+
+    /**
+     * @throws HelperException
+     */
+    protected function getForumsSelect(): array
+    {
+        $helper = $this->getHelperManager()->Forum();
+        $groups = [];
+
+        foreach ($helper->ensureGroupXmlIds($helper->getGroups()) as $group) {
+            $groups[$group['ID']] = '[' . $group['XML_ID'] . '] ' . $group['NAME'];
+        }
+
+        $items = $helper->ensureForumXmlIds($helper->getForums());
+
+        $items = array_map(function ($item) use ($groups) {
+            $item['GROUP_TITLE'] = $groups[$item['FORUM_GROUP_ID']] ?? Locale::getMessage('BUILDER_ForumExport_WithoutGroup');
+            $item['TITLE'] = '[' . $item['XML_ID'] . '] ' . $item['NAME'];
+            return $item;
+        }, $items);
+
+        return $this->createSelectWithGroups($items, 'ID', 'TITLE', 'GROUP_TITLE');
+    }
+}

--- a/lib/helpermanager.php
+++ b/lib/helpermanager.php
@@ -7,6 +7,7 @@ use Sprint\Migration\Helpers\AgentHelper;
 use Sprint\Migration\helpers\DeliveryServiceHelper;
 use Sprint\Migration\Helpers\EventHelper;
 use Sprint\Migration\Helpers\FormHelper;
+use Sprint\Migration\Helpers\ForumHelper;
 use Sprint\Migration\Helpers\HlblockExchangeHelper;
 use Sprint\Migration\Helpers\HlblockHelper;
 use Sprint\Migration\Helpers\IblockExchangeHelper;
@@ -42,6 +43,7 @@ use Sprint\Migration\Helpers\VoteHelper;
  * @method TaskHelper               Task()
  * @method OptionHelper             Option()
  * @method FormHelper               Form()
+ * @method ForumHelper              Forum()
  * @method VoteHelper               Vote()
  * @method DeliveryServiceHelper    DeliveryService()
  * @method SaleDiscountHelper       SaleDiscount()

--- a/lib/helpers/forumhelper.php
+++ b/lib/helpers/forumhelper.php
@@ -1,0 +1,810 @@
+<?php
+
+namespace Sprint\Migration\Helpers;
+
+use CForumGroup;
+use CForumNew;
+use CLanguage;
+use Sprint\Migration\Exceptions\HelperException;
+use Sprint\Migration\Helper;
+use Sprint\Migration\Locale;
+
+class ForumHelper extends Helper
+{
+    public function isEnabled(): bool
+    {
+        return $this->checkModules(['forum']);
+    }
+
+    /**
+     * @throws HelperException
+     */
+    public function getGroups(): array
+    {
+        $items = [];
+
+        foreach ($this->getForumGroupsRaw() as $item) {
+            $langs = $this->getGroupLangs((int)$item['ID']);
+            $item['NAME'] = $this->getFirstLangName($langs);
+            $items[] = $item;
+        }
+
+        return $items;
+    }
+
+    /**
+     * @throws HelperException
+     */
+    public function getForums(array $filter = []): array
+    {
+        return $this->fetchAll(CForumNew::GetList(
+            [
+                'FORUM_GROUP_ID' => 'ASC',
+                'SORT'           => 'ASC',
+                'NAME'           => 'ASC',
+                'ID'             => 'ASC',
+            ],
+            $filter
+        ));
+    }
+
+    /**
+     * @throws HelperException
+     */
+    public function ensureGroupXmlIds(array $items): array
+    {
+        foreach ($items as $index => $item) {
+            if (empty($item['XML_ID'])) {
+                $items[$index] = $this->ensureGroupXmlId($item);
+            }
+        }
+
+        return $items;
+    }
+
+    /**
+     * @throws HelperException
+     */
+    public function ensureGroupXmlId(array $item): array
+    {
+        $this->checkRequiredKeys($item, ['ID']);
+        $this->ensureGroupXmlIdColumn();
+
+        if (!empty($item['XML_ID'])) {
+            return $item;
+        }
+
+        if (empty($item['NAME'])) {
+            $item['NAME'] = $this->getFirstLangName($this->getGroupLangs((int)$item['ID']));
+        }
+
+        $item['XML_ID'] = $this->makeGroupXmlId($item);
+        $result = CForumGroup::Update((int)$item['ID'], [
+            'XML_ID'    => $item['XML_ID'],
+            'PARENT_ID' => $item['PARENT_ID'] ?? false,
+        ]);
+
+        if (!$result) {
+            $this->throwApplicationExceptionIfExists();
+            throw new HelperException("Forum group \"{$item['ID']}\" XML_ID not updated");
+        }
+
+        return $item;
+    }
+
+    /**
+     * @throws HelperException
+     */
+    public function ensureForumXmlIds(array $items): array
+    {
+        foreach ($items as $index => $item) {
+            if (empty($item['XML_ID'])) {
+                $items[$index] = $this->ensureForumXmlId($item);
+            }
+        }
+
+        return $items;
+    }
+
+    /**
+     * @throws HelperException
+     */
+    public function ensureForumXmlId(array $item): array
+    {
+        $this->checkRequiredKeys($item, ['ID', 'NAME']);
+
+        if (!empty($item['XML_ID'])) {
+            return $item;
+        }
+
+        $item['XML_ID'] = $this->makeForumXmlId($item);
+        $result = CForumNew::Update((int)$item['ID'], ['XML_ID' => $item['XML_ID']], false);
+
+        if (!$result) {
+            $this->throwApplicationExceptionIfExists();
+            throw new HelperException("Forum \"{$item['ID']}\" XML_ID not updated");
+        }
+
+        return $item;
+    }
+
+    /**
+     * @throws HelperException
+     */
+    public function exportGroupById(int $groupId): array
+    {
+        return $this->prepareExportGroup($this->getGroupById($groupId));
+    }
+
+    /**
+     * @throws HelperException
+     */
+    public function exportGroups(array $groupIds): array
+    {
+        return array_map(
+            fn($groupId) => $this->exportGroupById((int)$groupId),
+            $this->makeNonEmptyArray($groupIds)
+        );
+    }
+
+    /**
+     * @throws HelperException
+     */
+    public function exportForumById(int $forumId): array
+    {
+        return $this->prepareExportForum($this->getForumById($forumId));
+    }
+
+    /**
+     * @throws HelperException
+     */
+    public function exportForums(array $forumIds): array
+    {
+        return array_map(
+            fn($forumId) => $this->exportForumById((int)$forumId),
+            $this->makeNonEmptyArray($forumIds)
+        );
+    }
+
+    /**
+     * @throws HelperException
+     */
+    public function saveGroup(array $fields): int
+    {
+        $this->checkRequiredKeys($fields, ['XML_ID', 'LANG']);
+        $this->ensureGroupXmlIdColumn();
+
+        $fields = $this->prepareGroupFields($fields);
+        $groupId = $this->getGroupId($fields['XML_ID']);
+
+        if (!$groupId) {
+            return $this->addGroup($fields);
+        }
+
+        $exists = $this->exportGroupById($groupId);
+        $export = $this->prepareExportGroup($fields);
+
+        if ($this->checkDiff($exists, $export)) {
+            return $this->updateGroup($groupId, $fields);
+        }
+
+        return $groupId;
+    }
+
+    /**
+     * @throws HelperException
+     */
+    public function saveForum(array $fields): int
+    {
+        $this->checkRequiredKeys($fields, ['XML_ID', 'NAME', 'SITES']);
+
+        $fields = $this->prepareForumFields($fields);
+        $forumId = $this->getForumId($fields['XML_ID']);
+
+        if (!$forumId) {
+            return $this->addForum($fields);
+        }
+
+        $exists = $this->exportForumById($forumId);
+        $export = $this->prepareExportForum($fields);
+
+        if ($this->checkDiff($exists, $export)) {
+            return $this->updateForum($forumId, $fields);
+        }
+
+        return $forumId;
+    }
+
+    /**
+     * @throws HelperException
+     */
+    protected function addGroup(array $fields): int
+    {
+        $fields = $this->prepareGroupFieldsForSave($fields);
+        $groupId = CForumGroup::Add($fields);
+
+        if ($groupId) {
+            $this->outNotice(Locale::getMessage('FORUM_GROUP_UPDATED', ['#NAME#' => $this->getFirstLangName($fields['LANG'])]));
+            return (int)$groupId;
+        }
+
+        $this->throwApplicationExceptionIfExists();
+        throw new HelperException("Forum group \"{$fields['XML_ID']}\" not added");
+    }
+
+    /**
+     * @throws HelperException
+     */
+    protected function updateGroup(int $groupId, array $fields): int
+    {
+        $fields = $this->prepareGroupFieldsForSave($fields);
+        $result = CForumGroup::Update($groupId, $fields);
+
+        if ($result) {
+            $this->outNotice(Locale::getMessage('FORUM_GROUP_UPDATED', ['#NAME#' => $this->getFirstLangName($fields['LANG'])]));
+            return (int)$result;
+        }
+
+        $this->throwApplicationExceptionIfExists();
+        throw new HelperException("Forum group \"{$fields['XML_ID']}\" not updated");
+    }
+
+    /**
+     * @throws HelperException
+     */
+    protected function addForum(array $fields): int
+    {
+        $fields = $this->prepareForumFieldsForSave($fields);
+        $forumId = CForumNew::Add($fields);
+
+        if ($forumId) {
+            $this->outNotice(Locale::getMessage('FORUM_UPDATED', ['#NAME#' => $fields['NAME']]));
+            return (int)$forumId;
+        }
+
+        $this->throwApplicationExceptionIfExists();
+        throw new HelperException("Forum \"{$fields['XML_ID']}\" not added");
+    }
+
+    /**
+     * @throws HelperException
+     */
+    protected function updateForum(int $forumId, array $fields): int
+    {
+        $fields = $this->prepareForumFieldsForSave($fields);
+        $result = CForumNew::Update($forumId, $fields, false);
+
+        if ($result) {
+            $this->outNotice(Locale::getMessage('FORUM_UPDATED', ['#NAME#' => $fields['NAME']]));
+            return (int)$result;
+        }
+
+        $this->throwApplicationExceptionIfExists();
+        throw new HelperException("Forum \"{$fields['XML_ID']}\" not updated");
+    }
+
+    /**
+     * @throws HelperException
+     */
+    protected function getGroupById(int $groupId): array
+    {
+        $this->ensureGroupXmlIdColumn();
+
+        $item = $this->queryFetch("SELECT ID, SORT, PARENT_ID, LEFT_MARGIN, RIGHT_MARGIN, DEPTH_LEVEL, XML_ID FROM b_forum_group WHERE ID = " . $groupId);
+        if (empty($item)) {
+            throw new HelperException("Forum group \"$groupId\" not found");
+        }
+
+        $item = $this->ensureGroupXmlId($item);
+        $item['LANG'] = $this->getGroupLangs($groupId);
+
+        return $item;
+    }
+
+    /**
+     * @throws HelperException
+     */
+    protected function getForumById(int $forumId): array
+    {
+        $item = CForumNew::GetByID($forumId);
+        if (empty($item)) {
+            throw new HelperException("Forum \"$forumId\" not found");
+        }
+
+        $item = $this->ensureForumXmlId($item);
+        $item['SITES'] = CForumNew::GetSites($forumId) ?: [];
+        $item['PERMISSIONS'] = $this->exportForumPermissions($forumId);
+
+        return $item;
+    }
+
+    /**
+     * @throws HelperException
+     */
+    protected function getGroupId(string $xmlId): int
+    {
+        $this->ensureGroupXmlIdColumn();
+
+        $item = $this->queryFetch("SELECT ID FROM b_forum_group WHERE XML_ID = '" . $this->forSql($xmlId) . "' ORDER BY ID ASC LIMIT 1");
+        return (int)($item['ID'] ?? 0);
+    }
+
+    protected function getForumId(string $xmlId): int
+    {
+        $item = CForumNew::GetList(['ID' => 'ASC'], ['XML_ID' => $xmlId])->Fetch();
+        return (int)($item['ID'] ?? 0);
+    }
+
+    /**
+     * @throws HelperException
+     */
+    protected function prepareExportGroup(array $item): array
+    {
+        if (!empty($item['ID']) && empty($item['XML_ID'])) {
+            $item = $this->ensureGroupXmlId($item);
+        }
+
+        if (empty($item['LANG']) && !empty($item['ID'])) {
+            $item['LANG'] = $this->getGroupLangs((int)$item['ID']);
+        }
+
+        if (!empty($item['PARENT_ID'])) {
+            $item['PARENT'] = $this->exportGroupById((int)$item['PARENT_ID']);
+        }
+
+        $item = $this->prepareGroupFields($item);
+
+        return $this->export(
+            $item,
+            $this->getDefaultGroup(),
+            ['ID', 'PARENT_ID', 'LEFT_MARGIN', 'RIGHT_MARGIN', 'DEPTH_LEVEL']
+        );
+    }
+
+    /**
+     * @throws HelperException
+     */
+    protected function prepareGroupFields(array $item): array
+    {
+        $item = array_merge($this->getDefaultGroup(), $item);
+        $item['SORT'] = (string)$item['SORT'];
+        $item['LANG'] = array_values($item['LANG']);
+
+        return array_intersect_key(
+            $item,
+            array_flip([
+                'ID',
+                'XML_ID',
+                'SORT',
+                'PARENT_ID',
+                'PARENT',
+                'LEFT_MARGIN',
+                'RIGHT_MARGIN',
+                'DEPTH_LEVEL',
+                'LANG',
+            ])
+        );
+    }
+
+    /**
+     * @throws HelperException
+     */
+    protected function prepareGroupFieldsForSave(array $item): array
+    {
+        $item = $this->prepareGroupFields($item);
+
+        if (!empty($item['PARENT'])) {
+            $item['PARENT_ID'] = $this->saveGroup($item['PARENT']);
+        }
+
+        unset($item['ID'], $item['PARENT'], $item['LEFT_MARGIN'], $item['RIGHT_MARGIN'], $item['DEPTH_LEVEL']);
+
+        if (empty($item['PARENT_ID'])) {
+            $item['PARENT_ID'] = false;
+        }
+
+        $item['LANG'] = $this->fillMissingGroupLangs($item['LANG']);
+
+        return $item;
+    }
+
+    /**
+     * @throws HelperException
+     */
+    protected function prepareExportForum(array $item): array
+    {
+        if (!empty($item['ID']) && empty($item['XML_ID'])) {
+            $item = $this->ensureForumXmlId($item);
+        }
+
+        if (!isset($item['SITES']) && !empty($item['ID'])) {
+            $item['SITES'] = CForumNew::GetSites((int)$item['ID']) ?: [];
+        }
+
+        if (!isset($item['PERMISSIONS']) && !empty($item['ID'])) {
+            $item['PERMISSIONS'] = $this->exportForumPermissions((int)$item['ID']);
+        }
+
+        if (!empty($item['GROUP'])) {
+            $item['FORUM_GROUP_ID'] = $this->saveGroup($item['GROUP']);
+        }
+
+        if (!empty($item['FORUM_GROUP_ID'])) {
+            $item['GROUP'] = $this->exportGroupById((int)$item['FORUM_GROUP_ID']);
+        }
+
+        $item = $this->prepareForumFields($item);
+
+        return $this->export(
+            $item,
+            $this->getDefaultForum(),
+            [
+                'ID',
+                'LID',
+                'PATH2FORUM_MESSAGE',
+                'FORUM_GROUP_ID',
+                'TOPICS',
+                'POSTS',
+                'LAST_POSTER_ID',
+                'LAST_POSTER_NAME',
+                'LAST_POST_DATE',
+                'LAST_MESSAGE_ID',
+                'MID',
+                'POSTS_UNAPPROVED',
+                'ABS_LAST_POSTER_ID',
+                'ABS_LAST_POSTER_NAME',
+                'ABS_LAST_POST_DATE',
+                'ABS_LAST_MESSAGE_ID',
+            ]
+        );
+    }
+
+    protected function prepareForumFields(array $item): array
+    {
+        $item = array_merge($this->getDefaultForum(), $item);
+        $item['SORT'] = (string)$item['SORT'];
+        $item['SITES'] = is_array($item['SITES']) ? $item['SITES'] : [];
+        $item['PERMISSIONS'] = is_array($item['PERMISSIONS']) ? $item['PERMISSIONS'] : [];
+
+        ksort($item['SITES']);
+        ksort($item['PERMISSIONS']);
+
+        return array_intersect_key(
+            $item,
+            array_flip([
+                'ID',
+                'XML_ID',
+                'FORUM_GROUP_ID',
+                'GROUP',
+                'NAME',
+                'DESCRIPTION',
+                'SORT',
+                'ACTIVE',
+                'ALLOW_HTML',
+                'ALLOW_ANCHOR',
+                'ALLOW_BIU',
+                'ALLOW_IMG',
+                'ALLOW_VIDEO',
+                'ALLOW_LIST',
+                'ALLOW_QUOTE',
+                'ALLOW_CODE',
+                'ALLOW_FONT',
+                'ALLOW_SMILES',
+                'ALLOW_UPLOAD',
+                'ALLOW_TABLE',
+                'ALLOW_ALIGN',
+                'ALLOW_UPLOAD_EXT',
+                'ALLOW_MOVE_TOPIC',
+                'ALLOW_TOPIC_TITLED',
+                'ALLOW_NL2BR',
+                'ALLOW_SIGNATURE',
+                'ASK_GUEST_EMAIL',
+                'USE_CAPTCHA',
+                'INDEXATION',
+                'DEDUPLICATION',
+                'MODERATION',
+                'ORDER_BY',
+                'ORDER_DIRECTION',
+                'EVENT1',
+                'EVENT2',
+                'EVENT3',
+                'HTML',
+                'SITES',
+                'PERMISSIONS',
+                'LID',
+                'PATH2FORUM_MESSAGE',
+                'TOPICS',
+                'POSTS',
+                'LAST_POSTER_ID',
+                'LAST_POSTER_NAME',
+                'LAST_POST_DATE',
+                'LAST_MESSAGE_ID',
+                'MID',
+                'POSTS_UNAPPROVED',
+                'ABS_LAST_POSTER_ID',
+                'ABS_LAST_POSTER_NAME',
+                'ABS_LAST_POST_DATE',
+                'ABS_LAST_MESSAGE_ID',
+            ])
+        );
+    }
+
+    /**
+     * @throws HelperException
+     */
+    protected function prepareForumFieldsForSave(array $item): array
+    {
+        $item = $this->prepareForumFields($item);
+
+        if (!empty($item['GROUP'])) {
+            $item['FORUM_GROUP_ID'] = $this->saveGroup($item['GROUP']);
+        }
+
+        $item['GROUP_ID'] = $this->revertForumPermissions($item['PERMISSIONS']);
+
+        unset(
+            $item['ID'],
+            $item['GROUP'],
+            $item['PERMISSIONS'],
+            $item['LID'],
+            $item['PATH2FORUM_MESSAGE'],
+            $item['TOPICS'],
+            $item['POSTS'],
+            $item['LAST_POSTER_ID'],
+            $item['LAST_POSTER_NAME'],
+            $item['LAST_POST_DATE'],
+            $item['LAST_MESSAGE_ID'],
+            $item['MID'],
+            $item['POSTS_UNAPPROVED'],
+            $item['ABS_LAST_POSTER_ID'],
+            $item['ABS_LAST_POSTER_NAME'],
+            $item['ABS_LAST_POST_DATE'],
+            $item['ABS_LAST_MESSAGE_ID']
+        );
+
+        if (empty($item['FORUM_GROUP_ID'])) {
+            $item['FORUM_GROUP_ID'] = false;
+        }
+
+        return $item;
+    }
+
+    protected function getDefaultGroup(): array
+    {
+        return [
+            'SORT'      => '150',
+            'PARENT_ID' => false,
+            'LANG'      => [],
+        ];
+    }
+
+    protected function getDefaultForum(): array
+    {
+        return [
+            'DESCRIPTION'         => null,
+            'SORT'                => '150',
+            'ACTIVE'              => 'Y',
+            'ALLOW_HTML'          => 'N',
+            'ALLOW_ANCHOR'        => 'Y',
+            'ALLOW_BIU'           => 'Y',
+            'ALLOW_IMG'           => 'Y',
+            'ALLOW_VIDEO'         => 'Y',
+            'ALLOW_LIST'          => 'Y',
+            'ALLOW_QUOTE'         => 'Y',
+            'ALLOW_CODE'          => 'Y',
+            'ALLOW_FONT'          => 'Y',
+            'ALLOW_SMILES'        => 'Y',
+            'ALLOW_UPLOAD'        => 'N',
+            'ALLOW_TABLE'         => 'N',
+            'ALLOW_ALIGN'         => 'Y',
+            'ALLOW_UPLOAD_EXT'    => null,
+            'ALLOW_MOVE_TOPIC'    => 'Y',
+            'ALLOW_TOPIC_TITLED'  => 'N',
+            'ALLOW_NL2BR'         => 'N',
+            'ALLOW_SIGNATURE'     => 'Y',
+            'ASK_GUEST_EMAIL'     => 'N',
+            'USE_CAPTCHA'         => 'N',
+            'INDEXATION'          => 'Y',
+            'DEDUPLICATION'       => 'Y',
+            'MODERATION'          => 'N',
+            'ORDER_BY'            => 'P',
+            'ORDER_DIRECTION'     => 'DESC',
+            'EVENT1'              => 'forum',
+            'EVENT2'              => 'message',
+            'EVENT3'              => null,
+            'HTML'                => null,
+            'SITES'               => [],
+            'PERMISSIONS'         => [],
+        ];
+    }
+
+    /**
+     * @throws HelperException
+     */
+    protected function getForumGroupsRaw(): array
+    {
+        $this->ensureGroupXmlIdColumn();
+
+        return $this->queryFetchAll(
+            'SELECT ID, SORT, PARENT_ID, LEFT_MARGIN, RIGHT_MARGIN, DEPTH_LEVEL, XML_ID
+            FROM b_forum_group
+            ORDER BY LEFT_MARGIN ASC, SORT ASC, ID ASC'
+        );
+    }
+
+    protected function getGroupLangs(int $groupId): array
+    {
+        return $this->queryFetchAll(
+            'SELECT LID, NAME, DESCRIPTION
+            FROM b_forum_group_lang
+            WHERE FORUM_GROUP_ID = ' . $groupId . '
+            ORDER BY LID ASC'
+        );
+    }
+
+    protected function getFirstLangName(array $langs): string
+    {
+        $preferred = defined('LANGUAGE_ID') ? LANGUAGE_ID : 'ru';
+
+        foreach ([$preferred, 'ru'] as $lid) {
+            foreach ($langs as $lang) {
+                if (($lang['LID'] ?? '') === $lid && !empty($lang['NAME'])) {
+                    return (string)$lang['NAME'];
+                }
+            }
+        }
+
+        $lang = reset($langs);
+        return (string)($lang['NAME'] ?? '');
+    }
+
+    protected function fillMissingGroupLangs(array $langs): array
+    {
+        $activeLangIds = $this->getActiveLangIds();
+        if (empty($activeLangIds) || empty($langs)) {
+            return $langs;
+        }
+
+        $indexed = [];
+        foreach ($langs as $lang) {
+            if (!empty($lang['LID'])) {
+                $indexed[$lang['LID']] = $lang;
+            }
+        }
+
+        $default = reset($langs);
+        foreach ($activeLangIds as $lid) {
+            if (empty($indexed[$lid])) {
+                $indexed[$lid] = [
+                    'LID'         => $lid,
+                    'NAME'        => (string)($default['NAME'] ?? ''),
+                    'DESCRIPTION' => (string)($default['DESCRIPTION'] ?? ''),
+                ];
+            }
+        }
+
+        ksort($indexed);
+        return array_values($indexed);
+    }
+
+    protected function getActiveLangIds(): array
+    {
+        $by = 'sort';
+        $order = 'asc';
+        $items = [];
+
+        $dbres = CLanguage::GetList($by, $order, ['ACTIVE' => 'Y']);
+        while ($item = $dbres->Fetch()) {
+            $items[] = $item['LID'];
+        }
+
+        return $items;
+    }
+
+    protected function exportForumPermissions(int $forumId): array
+    {
+        $groupHelper = new UserGroupHelper();
+        $permissions = [];
+
+        foreach (CForumNew::GetAccessPermissions($forumId) as $permission) {
+            $groupCode = $groupHelper->getGroupCode((int)$permission[0]);
+            if ($groupCode) {
+                $permissions[$groupCode] = (string)$permission[1];
+            }
+        }
+
+        ksort($permissions);
+        return $permissions;
+    }
+
+    /**
+     * @throws HelperException
+     */
+    protected function revertForumPermissions(array $permissions): array
+    {
+        $groupHelper = new UserGroupHelper();
+        $result = [];
+
+        foreach ($permissions as $groupCode => $permission) {
+            $groupId = $groupHelper->getGroupIdIfExists((string)$groupCode);
+            $result[$groupId] = (string)$permission;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @throws HelperException
+     */
+    protected function ensureGroupXmlIdColumn(): void
+    {
+        $sqlHelper = new SqlHelper();
+
+        if (!$sqlHelper->hasColumn('b_forum_group', 'XML_ID')) {
+            $sqlHelper->query('ALTER TABLE b_forum_group ADD XML_ID varchar(255) NULL');
+        }
+    }
+
+    protected function makeGroupXmlId(array $item): string
+    {
+        $slug = $this->makeCodeSlug((string)($item['NAME'] ?? ''));
+        if ($slug === '') {
+            $slug = 'GROUP';
+        }
+
+        return sprintf('FORUM_GROUP_%d_%s', (int)$item['ID'], $slug);
+    }
+
+    protected function makeForumXmlId(array $item): string
+    {
+        $slug = $this->makeCodeSlug((string)($item['NAME'] ?? ''));
+        if ($slug === '') {
+            $slug = 'FORUM';
+        }
+
+        return sprintf('FORUM_%d_%s', (int)$item['ID'], $slug);
+    }
+
+    protected function makeCodeSlug(string $value): string
+    {
+        if (class_exists('CUtil')) {
+            $value = \CUtil::translit($value, 'ru', [
+                'replace_space' => '_',
+                'replace_other' => '_',
+                'change_case'   => 'U',
+            ]);
+        }
+
+        $value = strtoupper($value);
+        $value = preg_replace('/[^A-Z0-9_]+/', '_', $value);
+        $value = trim((string)$value, '_');
+
+        return preg_replace('/_+/', '_', $value);
+    }
+
+    protected function queryFetch(string $sql): bool|array
+    {
+        $res = $this->queryFetchAll($sql);
+        return $res[0] ?? false;
+    }
+
+    protected function queryFetchAll(string $sql): array
+    {
+        global $DB;
+
+        $items = [];
+        $dbres = $DB->Query($sql);
+        while ($item = $dbres->Fetch()) {
+            $items[] = $item;
+        }
+
+        return $items;
+    }
+
+    protected function forSql(string $value, int $maxLength = 0): string
+    {
+        global $DB;
+
+        return $DB->ForSql($value, $maxLength);
+    }
+}

--- a/lib/versionconfig.php
+++ b/lib/versionconfig.php
@@ -7,6 +7,7 @@ use Sprint\Migration\Builders\BlankBuilder;
 use Sprint\Migration\Builders\CacheCleanerBuilder;
 use Sprint\Migration\Builders\EventBuilder;
 use Sprint\Migration\Builders\FormBuilder;
+use Sprint\Migration\Builders\ForumBuilder;
 use Sprint\Migration\Builders\HlblockBuilder;
 use Sprint\Migration\Builders\HlblockElementsBuilder;
 use Sprint\Migration\Builders\IblockBuilder;
@@ -274,6 +275,7 @@ class VersionConfig
             'AgentBuilder'            => AgentBuilder::class,
             'OptionBuilder'           => OptionBuilder::class,
             'FormBuilder'             => FormBuilder::class,
+            'ForumBuilder'            => ForumBuilder::class,
             'VoteBuilder'             => VoteBuilder::class,
             'EventBuilder'            => EventBuilder::class,
             'SubscribeBuilder'        => SubscribeBuilder::class,

--- a/locale/en.php
+++ b/locale/en.php
@@ -78,6 +78,8 @@
         "LOADING_TEXT"             => "Loading...",
         "SALE_DISCOUNT_UPDATED"    => "Cart rule #NAME# saved",
         "SUBSCRIBE_RUBRIC_UPDATED" => "Subscription rubric #NAME# saved",
+        "FORUM_GROUP_UPDATED"      => "Forum group #NAME# saved",
+        "FORUM_UPDATED"            => "Forum #NAME# saved",
     ]
 );
 \Sprint\Migration\Locale::loadLocale(
@@ -116,6 +118,13 @@
         "BUILDER_TransferSelect"             => "Select migrations",
         "BUILDER_EventExport1"               => "Create migration for event types",
         "BUILDER_EventExport_event_types"    => "Select event types",
+        "BUILDER_ForumExport1"               => "Create migration for forums",
+        "BUILDER_ForumExport_group_ids"      => "Select forum groups",
+        "BUILDER_ForumExport_forum_ids"      => "Select forums",
+        "BUILDER_ForumExport_Info"           => "Forum group is exported with the forum automatically when it is set for the selected forum. If XML_ID is empty, it will be generated before export",
+        "BUILDER_ForumExport_RootGroups"     => "Root groups",
+        "BUILDER_ForumExport_NestedGroups"   => "Nested groups",
+        "BUILDER_ForumExport_WithoutGroup"   => "Without group",
         "BUILDER_SubscribeExport1"           => "Create migration for subscription rubrics",
         "BUILDER_SubscribeExport_rubric_ids" => "Select subscription rubrics",
         "BUILDER_SubscribeExport_Info"       => "Subscription rubric must have a symbolic code filled in",
@@ -498,6 +507,7 @@
         "BUILDER_GROUP_Hlblock"   => "Highload information blocks",
         "BUILDER_GROUP_Sale"      => "Sale module",
         "BUILDER_GROUP_Form"      => "Web Forms",
+        "BUILDER_GROUP_Forum"     => "Forums",
         "BUILDER_GROUP_Vote"      => "Polls",
         "BUILDER_GROUP_Subscribe" => "Subscriptions",
         "BUILDER_GROUP_Medialib"  => "Media Library",

--- a/locale/ru.php
+++ b/locale/ru.php
@@ -78,6 +78,8 @@
         "LOADING_TEXT"             => "Загрузка...",
         "SALE_DISCOUNT_UPDATED"    => "Правило корзины #NAME# сохранено",
         "SUBSCRIBE_RUBRIC_UPDATED" => "Рубрика подписки #NAME# сохранена",
+        "FORUM_GROUP_UPDATED"      => "Группа форумов #NAME# сохранена",
+        "FORUM_UPDATED"            => "Форум #NAME# сохранен",
     ]
 );
 \Sprint\Migration\Locale::loadLocale(
@@ -116,6 +118,13 @@
         "BUILDER_TransferSelect"             => "Выбрать миграции",
         "BUILDER_EventExport1"               => "Создать миграцию для почтовых событий",
         "BUILDER_EventExport_event_types"    => "Выберите типы почтовых событий",
+        "BUILDER_ForumExport1"               => "Создать миграцию для форумов",
+        "BUILDER_ForumExport_group_ids"      => "Выберите группы форумов",
+        "BUILDER_ForumExport_forum_ids"      => "Выберите форумы",
+        "BUILDER_ForumExport_Info"           => "Группа форума переносится вместе с форумом автоматически, если она указана у выбранного форума. Если XML_ID не заполнен, он будет сгенерирован перед экспортом",
+        "BUILDER_ForumExport_RootGroups"     => "Корневые группы",
+        "BUILDER_ForumExport_NestedGroups"   => "Вложенные группы",
+        "BUILDER_ForumExport_WithoutGroup"   => "Без группы",
         "BUILDER_SubscribeExport1"           => "Создать миграцию для рубрик подписок",
         "BUILDER_SubscribeExport_rubric_ids" => "Выберите рубрики подписок",
         "BUILDER_SubscribeExport_Info"       => "У подписки должен быть заполнен Символьный код",
@@ -496,6 +505,7 @@
         "BUILDER_GROUP_Hlblock"   => "Highload-блоки",
         "BUILDER_GROUP_Sale"      => "Интернет-магазин",
         "BUILDER_GROUP_Form"      => "Веб-формы",
+        "BUILDER_GROUP_Forum"     => "Форумы",
         "BUILDER_GROUP_Subscribe" => "Подписки",
         "BUILDER_GROUP_Vote"      => "Опросы",
         "BUILDER_GROUP_Medialib"  => "Медиабиблиотека",

--- a/templates/ForumExport.php
+++ b/templates/ForumExport.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @var $version
+ * @var $description
+ * @var $groups
+ * @var $forums
+ * @var $extendUse
+ * @var $extendClass
+ * @var $moduleVersion
+ * @var $author
+ * @formatter:off
+ */
+
+?><?php echo "<?php\n" ?>
+
+namespace Sprint\Migration;
+
+<?php echo $extendUse ?>
+
+class <?php echo $version ?> extends <?php echo $extendClass ?>
+
+{
+    protected $author = "<?php echo $author ?>";
+
+    protected $description = "<?php echo $description ?>";
+
+    protected $moduleVersion = "<?php echo $moduleVersion ?>";
+
+    /**
+     * @throws Exceptions\HelperException
+     * @return bool|void
+     */
+    public function up()
+    {
+        $helper = $this->getHelperManager();
+<?php foreach ($groups as $group) { ?>
+        $helper->Forum()->saveGroup(<?php echo var_export($group, 1) ?>);
+<?php } ?>
+<?php foreach ($forums as $forum) { ?>
+        $helper->Forum()->saveForum(<?php echo var_export($forum, 1) ?>);
+<?php } ?>
+    }
+}


### PR DESCRIPTION
Добавляет перенос форумов через Sprint Migration.

  Что сделано:
  - добавлен `ForumBuilder`;
  - добавлен `ForumHelper`;
  - добавлен шаблон миграции `ForumExport`;
  - команда добавлена в раздел `Форумы`;
  - в миграции выбираются только форумы;
  - группа форума переносится вместе с форумом автоматически, если она указана у выбранного форума;
  - если форум находится на верхнем уровне без группы, он переносится без группы;
  - если у форума или группы форума не заполнен `XML_ID`, он генерируется перед экспортом.

  Как сделано:
  - форум ищется и обновляется по `XML_ID`;
  - группа форума ищется и обновляется по `XML_ID`;
  - для сохранения используются штатные API форума: `CForumNew` и `CForumGroup`;
  - права форума переносятся через коды групп пользователей (`STRING_ID`);
  - привязки форума к сайтам переносятся через `SITES`;
  - статистика, темы, сообщения, подписки и вложения форумов не переносятся.