### PR TITLE
Добавил iblock property delete builder

### DIFF
--- a/lib/builders/iblockpropertydeletebuilder.php
+++ b/lib/builders/iblockpropertydeletebuilder.php
@@ -60,7 +60,7 @@ class IblockPropertyDeleteBuilder extends VersionBuilder
                 'width'    => 350,
                 'multiple' => 1,
                 'value'    => [],
-                'items'    => $this->createSelect($properties, 'ID', 'PROPERTY_TITLE'),
+                'select'   => $this->createSelect($properties, 'ID', 'PROPERTY_TITLE'),
             ]
         );
 

--- a/lib/builders/iblockpropertydeletebuilder.php
+++ b/lib/builders/iblockpropertydeletebuilder.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Sprint\Migration\Builders;
+
+use Sprint\Migration\Exceptions\HelperException;
+use Sprint\Migration\Exceptions\MigrationException;
+use Sprint\Migration\Exceptions\RebuildException;
+use Sprint\Migration\Locale;
+use Sprint\Migration\Module;
+use Sprint\Migration\VersionBuilder;
+
+class IblockPropertyDeleteBuilder extends VersionBuilder
+{
+    protected function isBuilderEnabled(): bool
+    {
+        return $this->getHelperManager()->Iblock()->isEnabled();
+    }
+
+    protected function initialize(): void
+    {
+        $this->setTitle(Locale::getMessage('BUILDER_IblockPropertyDelete'));
+        $this->setDescription(Locale::getMessage('BUILDER_IblockPropertyDelete_Info'));
+        $this->setGroup(Locale::getMessage('BUILDER_GROUP_Iblock'));
+
+        $this->addVersionFields();
+    }
+
+    /**
+     * @throws HelperException
+     * @throws MigrationException
+     * @throws RebuildException
+     */
+    protected function execute(): void
+    {
+        $helper = $this->getHelperManager();
+
+        $iblocks = $helper->IblockExchange()->getIblocks();
+        $iblockTypes = $helper->IblockExchange()->getIblockTypes();
+        $itemsForSelect = $helper->IblockExchange()->createIblocksStructure(
+            $iblockTypes,
+            $iblocks
+        );
+
+        $iblockId = (int)$this->addFieldAndReturn(
+            'iblock_id',
+            [
+                'title'       => Locale::getMessage('BUILDER_IblockExport_IblockId'),
+                'placeholder' => '',
+                'width'       => 250,
+                'items'       => $itemsForSelect,
+            ]
+        );
+
+        $properties = $this->prepareProperties($helper->Iblock()->getProperties($iblockId));
+
+        $this->addField(
+            'property_ids',
+            [
+                'title'    => Locale::getMessage('BUILDER_IblockPropertyDelete_Properties'),
+                'width'    => 350,
+                'multiple' => 1,
+                'value'    => [],
+                'items'    => $this->createSelect($properties, 'ID', 'PROPERTY_TITLE'),
+            ]
+        );
+
+        $this->addField(
+            'property_codes',
+            [
+                'title' => Locale::getMessage('BUILDER_IblockPropertyDelete_Codes'),
+                'width' => 350,
+                'height' => 80,
+            ]
+        );
+
+        $propertyIds = $this->getFieldValue('property_ids', []);
+        $propertyIds = is_array($propertyIds) ? $propertyIds : [$propertyIds];
+
+        $propertyCodes = $this->getPropertyCodesByIds($properties, $propertyIds);
+        $propertyCodes = array_merge(
+            $propertyCodes,
+            $this->explodePropertyCodes((string)$this->getFieldValue('property_codes'))
+        );
+        $propertyCodes = array_values(array_unique(array_filter($propertyCodes)));
+
+        if (empty($propertyCodes)) {
+            $this->rebuildField('property_ids');
+        }
+
+        $this->createVersionFile(
+            Module::getModuleTemplateFile('IblockPropertyDelete'),
+            [
+                'iblock'        => $helper->Iblock()->exportIblock($iblockId),
+                'propertyCodes' => $propertyCodes,
+            ],
+            false
+        );
+    }
+
+    private function prepareProperties(array $properties): array
+    {
+        $properties = array_filter(
+            $properties,
+            fn($property) => !empty($property['CODE'])
+        );
+
+        return array_map(
+            fn($property) => array_merge(
+                $property,
+                [
+                    'PROPERTY_TITLE' => sprintf('[%s] %s', $property['CODE'], $property['NAME']),
+                ]
+            ),
+            $properties
+        );
+    }
+
+    private function getPropertyCodesByIds(array $properties, array $propertyIds): array
+    {
+        $propertyIds = array_map('strval', $propertyIds);
+
+        return array_values(
+            array_map(
+                fn($property) => $property['CODE'],
+                array_filter(
+                    $properties,
+                    fn($property) => in_array((string)$property['ID'], $propertyIds, true)
+                )
+            )
+        );
+    }
+
+    private function explodePropertyCodes(string $codes): array
+    {
+        return array_filter(
+            array_map(
+                'trim',
+                preg_split('/[\s,;]+/', $codes) ?: []
+            )
+        );
+    }
+}

--- a/lib/versionconfig.php
+++ b/lib/versionconfig.php
@@ -14,6 +14,7 @@ use Sprint\Migration\Builders\IblockCategoryBuilder;
 use Sprint\Migration\Builders\IblockDeleteBuilder;
 use Sprint\Migration\Builders\IblockElementsBuilder;
 use Sprint\Migration\Builders\IblockPropertyBuilder;
+use Sprint\Migration\Builders\IblockPropertyDeleteBuilder;
 use Sprint\Migration\Builders\MarkerBuilder;
 use Sprint\Migration\Builders\MedialibElementsBuilder;
 use Sprint\Migration\Builders\OptionBuilder;
@@ -265,6 +266,7 @@ class VersionConfig
             'UserGroupBuilder'        => UserGroupBuilder::class,
             'IblockBuilder'           => IblockBuilder::class,
             'IblockPropertyBuilder'   => IblockPropertyBuilder::class,
+            'IblockPropertyDeleteBuilder' => IblockPropertyDeleteBuilder::class,
             'IblockCategoryBuilder'   => IblockCategoryBuilder::class,
             'IblockElementsBuilder'   => IblockElementsBuilder::class,
             'IblockDeleteBuilder'     => IblockDeleteBuilder::class,

--- a/locale/en.php
+++ b/locale/en.php
@@ -186,6 +186,10 @@
         "BUILDER_IblockPropertyExport1"           => "Create migration for information block properties",
         "BUILDER_IblockPropertyExport_UserType"   => "Select property type",
         "BUILDER_IblockPropertyExport_Properties" => "Select properties",
+        "BUILDER_IblockPropertyDelete"            => "Delete information block properties",
+        "BUILDER_IblockPropertyDelete_Info"       => "Deletes selected properties and properties with specified CODE. Missing property is not an error.",
+        "BUILDER_IblockPropertyDelete_Properties" => "Select properties",
+        "BUILDER_IblockPropertyDelete_Codes"      => "Property codes to delete",
     ]
 );
 

--- a/locale/ru.php
+++ b/locale/ru.php
@@ -184,6 +184,10 @@
         "BUILDER_IblockPropertyExport1"           => "Создать миграцию свойств инфоблоков",
         "BUILDER_IblockPropertyExport_UserType"   => "Выберите тип свойства",
         "BUILDER_IblockPropertyExport_Properties" => "Выберите свойства",
+        "BUILDER_IblockPropertyDelete"            => "Удалить свойства инфоблока",
+        "BUILDER_IblockPropertyDelete_Info"       => "Удаляет выбранные свойства и свойства с указанными CODE. Отсутствие свойства не считается ошибкой.",
+        "BUILDER_IblockPropertyDelete_Properties" => "Выберите свойства",
+        "BUILDER_IblockPropertyDelete_Codes"      => "Коды свойств для удаления",
     ]
 );
 \Sprint\Migration\Locale::loadLocale(

--- a/templates/IblockPropertyDelete.php
+++ b/templates/IblockPropertyDelete.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @var string $version
+ * @var string $description
+ * @var string $extendUse
+ * @var string $extendClass
+ * @var string $moduleVersion
+ * @var string $author
+ * @var array $iblock
+ * @var array $propertyCodes
+ * @formatter:off
+ */
+
+?><?php echo "<?php\n" ?>
+
+namespace Sprint\Migration;
+
+<?php echo $extendUse ?>
+
+class <?php echo $version ?> extends <?php echo $extendClass ?>
+
+{
+    protected $author = "<?php echo $author ?>";
+
+    protected $description = "<?php echo $description ?>";
+
+    protected $moduleVersion = "<?php echo $moduleVersion ?>";
+
+    /**
+     * @throws Exceptions\HelperException
+     * @return bool|void
+     */
+    public function up()
+    {
+        $helper = $this->getHelperManager();
+        $iblockId = $helper->Iblock()->getIblockIdIfExists(
+            <?php echo var_export((string)$iblock['CODE'], 1) ?>,
+            <?php echo var_export((string)$iblock['IBLOCK_TYPE_ID'], 1) ?>
+        );
+
+<?php foreach ($propertyCodes as $propertyCode) {?>
+        $helper->Iblock()->deletePropertyIfExists($iblockId, <?php echo var_export((string)$propertyCode, 1) ?>);
+<?php } ?>
+    }
+}


### PR DESCRIPTION
Добавлен отдельный builder в разделе Инфоблоки:
Удалить свойства инфоблока
Закрыл https://github.com/andreyryabin/sprint.migration/issues/177

## В форме можно:
  - выбрать инфоблок;
  - выбрать существующие свойства из списка;
  - дополнительно указать коды свойств вручную;
  - создать миграцию, которая удалит выбранные свойства через Iblock()->deletePropertyIfExists().

## Ограничения

- Миграция удаляет свойства только по CODE внутри выбранного инфоблока.
- Если свойство отсутствует при применении миграции, это не считается ошибкой. 
- Миграция не восстанавливает удаленные свойства и не хранит их полную структуру для отката.

## Предупреждения
**Откат запрещен явно: в сгенерированной миграции есть down(), который выбрасывает ошибку:**
Откат миграции невозможен: удаленные свойства инфоблока не могут быть восстановлены автоматически.