### PR TITLE
Fix PHP 8.5 nullable deprecation in HelperException

### DIFF
--- a/lib/exceptions/helperexception.php
+++ b/lib/exceptions/helperexception.php
@@ -7,7 +7,7 @@ use Throwable;
 
 class HelperException extends Exception
 {
-    public function __construct($message = "", $code = 0, Throwable $previous = null)
+    public function __construct($message = "", $code = 0, ?Throwable $previous = null)
     {
         $message = is_array($message) ? implode(', ', $message) : $message;
 


### PR DESCRIPTION
 Исправляет deprecation warning на PHP 8.5 в `HelperException`.

  Что сделано:
  - параметр `$previous` в конструкторе `HelperException` явно помечен как nullable: `?Throwable $previous = null`.
  - изменение обратно совместимо с PHP 8.1+

  Зачем:
  - PHP 8.5 предупреждает об implicit nullable type для `Throwable $previous = null`.

  Проверка:
  - `php:8.5-cli`
  - `php -d error_reporting=E_ALL -l lib/exceptions/helperexception.php`
  - полный `php -d error_reporting=E_ALL -l` по всем PHP-файлам модуля