### PR TITLE
Добавил поддержку S3 

### DIFF
--- a/lib/builders/formbuilder.php
+++ b/lib/builders/formbuilder.php
@@ -39,7 +39,9 @@ class FormBuilder extends VersionBuilder
             'select' => $this->getFormsSelect(),
         ]);
 
-        $form = $helper->Form()->exportFormById($formId);
+        $exchangeDir = $this->getVersionExchangeDir();
+
+        $form = $helper->Form()->exportFormById($formId, $exchangeDir);
 
         $what = $this->addFieldAndReturn('what', [
             'title'    => Locale::getMessage('BUILDER_FormExport_What'),
@@ -95,10 +97,10 @@ class FormBuilder extends VersionBuilder
                         'select'   => $this->getFieldsSelect($formId),
                     ]
                 );
-                $fields = $helper->Form()->exportFormFields($formId, $fieldsSomeSids);
+                $fields = $helper->Form()->exportFormFields($formId, $fieldsSomeSids, $exchangeDir);
             }
             if ($fieldsMode == 'all') {
-                $fields = $helper->Form()->exportFormFields($formId);
+                $fields = $helper->Form()->exportFormFields($formId, [], $exchangeDir);
             }
         }
 

--- a/lib/builders/hlblockelementsbuilder.php
+++ b/lib/builders/hlblockelementsbuilder.php
@@ -70,12 +70,13 @@ class HlblockElementsBuilder extends VersionBuilder
                     $hlblockId,
                     $exportFilter
                 ),
-                recordsFn: fn($offset, $limit) => $exhelper->getWriterRecordsTag(
+                recordsFn: fn($offset, $limit, $exchangeDir) => $exhelper->getWriterRecordsTag(
                     $offset,
                     $limit,
                     $hlblockId,
                     $exportFilter,
-                    $exportFields
+                    $exportFields,
+                    $exchangeDir
                 ),
                 progressFn: fn($value, $totalCount) => $this->outProgress(
                     'Progress: ',

--- a/lib/builders/iblockcategorybuilder.php
+++ b/lib/builders/iblockcategorybuilder.php
@@ -52,7 +52,7 @@ class IblockCategoryBuilder extends VersionBuilder
             $this->rebuildField('iblock_id');
         }
 
-        $sectionTree = $helper->Iblock()->exportSectionsTree($iblockId);
+        $sectionTree = $helper->Iblock()->exportSectionsTree($iblockId, $this->getVersionExchangeDir());
 
         $this->createVersionFile(
             Module::getModuleTemplateFile('IblockCategoryExport'),

--- a/lib/builders/iblockelementsbuilder.php
+++ b/lib/builders/iblockelementsbuilder.php
@@ -63,13 +63,14 @@ class IblockElementsBuilder extends VersionBuilder
                     $iblockId,
                     $exportFilter
                 ),
-                recordsFn: fn($offset, $limit) => $exhelper->getWriterRecordsTag(
+                recordsFn: fn($offset, $limit, $exchangeDir) => $exhelper->getWriterRecordsTag(
                     $offset,
                     $limit,
                     $iblockId,
                     $exportFilter,
                     $exportFields,
-                    $exportProps
+                    $exportProps,
+                    $exchangeDir
                 ),
                 progressFn: fn($value, $totalCount) => $this->outProgress(
                     'Progress: ',

--- a/lib/exchange/fileexchange.php
+++ b/lib/exchange/fileexchange.php
@@ -1,0 +1,549 @@
+<?php
+
+namespace Sprint\Migration\Exchange;
+
+use CFile;
+use Sprint\Migration\Exceptions\MigrationException;
+use Sprint\Migration\Module;
+
+class FileExchange
+{
+    private ?array $localHosts = null;
+
+    public function exportFileById(int $fileId, string $exchangeDir = '', string $subdir = 'files'): array|false
+    {
+        if (!$fileId || $exchangeDir === '') {
+            return false;
+        }
+
+        $file = CFile::GetFileArray($fileId);
+        if (empty($file)) {
+            return false;
+        }
+
+        $relativePath = trim($subdir . '/' . $file['SUBDIR'] . '/' . $file['FILE_NAME'], '/');
+        $target = rtrim($exchangeDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $relativePath;
+
+        if (!$this->copyFileIdToPath($fileId, $target) && !$this->copyFileArrayToPath($file, $target)) {
+            return false;
+        }
+
+        return $this->makeFileRef($relativePath, $file);
+    }
+
+    public function exportFileByLink(string $link, string $exchangeDir = '', string $subdir = 'files'): array|false
+    {
+        if ($link === '' || $exchangeDir === '') {
+            return false;
+        }
+
+        $path = parse_url($link, PHP_URL_PATH);
+        if (!is_string($path) || $path === '') {
+            return false;
+        }
+
+        if ($this->isLocalUploadLink($link)) {
+            $fileId = $this->getFileIdByUploadPath($path);
+            if ($fileId) {
+                $fileRef = $this->exportFileById($fileId, $exchangeDir, $subdir);
+                if ($fileRef) {
+                    $fileRef['source'] = $link;
+                    return $fileRef;
+                }
+            }
+
+            $source = Module::getDocRoot() . rawurldecode($path);
+            if (is_file($source)) {
+                return $this->exportLocalFile($source, $exchangeDir, $subdir, $link);
+            }
+        }
+
+        if ($this->isCloudStorageLink($link)) {
+            return $this->exportCloudStorageLink($link, $exchangeDir, $subdir);
+        }
+
+        return false;
+    }
+
+    public function exportTextFileLinks(array|string $texts, string $exchangeDir = '', string $subdir = 'files'): array
+    {
+        $result = [];
+        foreach ((array)$texts as $text) {
+            foreach ($this->extractFileLinks((string)$text) as $link) {
+                $fileRef = $this->exportFileByLink($link, $exchangeDir, $subdir);
+                if ($fileRef) {
+                    $result[$link] = $fileRef;
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    public function extractFileLinks(string $text): array
+    {
+        $links = [];
+
+        $links = array_merge(
+            $links,
+            $this->extractAttributeFileLinks($text),
+            $this->extractSrcsetFileLinks($text),
+            $this->extractCssFileLinks($text)
+        );
+
+        if (preg_match_all('/\[IMG\]([^\[]+)\[\/IMG\]/iu', $text, $matches)) {
+            foreach ($matches[1] as $link) {
+                $links[] = trim($link);
+            }
+        }
+
+        return array_values(array_unique(array_filter(
+            $links,
+            fn($link) => $this->isSupportedFileLink((string)$link)
+        )));
+    }
+
+    public function replaceTextFileLinks(string $text, array $linkMap): string
+    {
+        if (empty($linkMap)) {
+            return $text;
+        }
+
+        foreach ($linkMap as $oldLink => $newLink) {
+            if (!is_string($oldLink) || $oldLink === '' || !is_string($newLink) || $newLink === '') {
+                continue;
+            }
+
+            $text = str_replace($this->getLinkReplaceVariants($oldLink), $newLink, $text);
+        }
+
+        return $text;
+    }
+
+    public function makeFileArrayByRef(array $fileRef, string $exchangeDir = ''): array|false
+    {
+        if (empty($fileRef['path']) || $exchangeDir === '') {
+            return false;
+        }
+
+        $path = rtrim($exchangeDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . ltrim($fileRef['path'], DIRECTORY_SEPARATOR);
+        $file = CFile::MakeFileArray($path);
+        if (empty($file)) {
+            return false;
+        }
+
+        if (!empty($fileRef['name'])) {
+            $file['name'] = $fileRef['name'];
+        }
+        if (!empty($fileRef['description'])) {
+            $file['description'] = $fileRef['description'];
+        }
+        if (!empty($fileRef['content_type'])) {
+            $file['type'] = $fileRef['content_type'];
+        }
+
+        return $file;
+    }
+
+    public function saveFileRefAndGetPath(
+        array $fileRef,
+        string $exchangeDir = '',
+        string $module = 'sprint_migration'
+    ): string {
+        $file = $this->makeFileArrayByRef($fileRef, $exchangeDir);
+        if (!$file) {
+            return '';
+        }
+
+        Module::prepareLongDatabaseConnection();
+        $fileId = CFile::SaveFile($file, $module);
+        Module::reconnectDatabase();
+
+        return $fileId ? (string)CFile::GetPath($fileId) : '';
+    }
+
+    public function copyFileArrayToPath(array $file, string $target): bool
+    {
+        $source = $this->getLocalFilePath($file);
+        if ($source && is_file($source)) {
+            return $this->copyLocalFile($source, $target);
+        }
+
+        $url = $this->getFileUrl($file);
+        if ($url) {
+            return $this->copyRemoteFile($url, $target);
+        }
+
+        return false;
+    }
+
+    /**
+     * @throws MigrationException
+     */
+    private function copyFileIdToPath(int $fileId, string $target): bool
+    {
+        $file = CFile::MakeFileArray($fileId);
+        if (empty($file['tmp_name'])) {
+            return false;
+        }
+
+        return $this->copyFileArrayTmpToPath($file, $target);
+    }
+
+    /**
+     * @throws MigrationException
+     */
+    private function copyFileArrayTmpToPath(array $file, string $target): bool
+    {
+        $source = (string)($file['tmp_name'] ?? '');
+        if ($source === '' || !is_file($source)) {
+            return false;
+        }
+
+        return $this->copyLocalFile($source, $target);
+    }
+
+    /**
+     * @throws MigrationException
+     */
+    private function copyLocalFile(string $source, string $target): bool
+    {
+        Module::createDir(dirname($target));
+        return copy($source, $target);
+    }
+
+    /**
+     * @throws MigrationException
+     */
+    private function copyRemoteFile(string $url, string $target): bool
+    {
+        $content = $this->getRemoteFileContent($url);
+        if ($content === false) {
+            return false;
+        }
+
+        Module::createDir(dirname($target));
+        return file_put_contents($target, $content) !== false;
+    }
+
+    private function getRemoteFileContent(string $url): string|false
+    {
+        if (class_exists('\Bitrix\Main\Web\HttpClient')) {
+            $client = new \Bitrix\Main\Web\HttpClient([
+                'socketTimeout' => 30,
+                'streamTimeout' => 30,
+                'redirect' => true,
+            ]);
+
+            $content = $client->get($url);
+            if ($content !== false && $client->getStatus() >= 200 && $client->getStatus() < 300) {
+                return $content;
+            }
+        }
+
+        if (filter_var(ini_get('allow_url_fopen'), FILTER_VALIDATE_BOOL)) {
+            $context = stream_context_create([
+                'http' => [
+                    'timeout' => 30,
+                    'follow_location' => 1,
+                ],
+                'https' => [
+                    'timeout' => 30,
+                    'follow_location' => 1,
+                ],
+            ]);
+
+            return @file_get_contents($url, false, $context);
+        }
+
+        return false;
+    }
+
+    private function exportLocalFile(string $source, string $exchangeDir, string $subdir, string $sourceLink): array|false
+    {
+        $fileName = basename($source);
+        $relativePath = trim($subdir . '/' . md5($sourceLink) . '_' . $fileName, '/');
+        $target = rtrim($exchangeDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $relativePath;
+
+        if (!$this->copyLocalFile($source, $target)) {
+            return false;
+        }
+
+        return [
+            'path' => $relativePath,
+            'name' => $fileName,
+            'source' => $sourceLink,
+        ];
+    }
+
+    private function exportCloudStorageLink(string $url, string $exchangeDir, string $subdir): array|false
+    {
+        $file = CFile::MakeFileArray($url);
+        if (empty($file)) {
+            return false;
+        }
+
+        $path = parse_url($url, PHP_URL_PATH);
+        $fileName = ($file['name'] ?? basename((string)$path)) ?: md5($url);
+        $relativePath = trim($subdir . '/' . md5($url) . '_' . $fileName, '/');
+        $target = rtrim($exchangeDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $relativePath;
+
+        if (!$this->copyFileArrayTmpToPath($file, $target)) {
+            return false;
+        }
+
+        return array_filter([
+            'path' => $relativePath,
+            'name' => $fileName,
+            'description' => $file['description'] ?? '',
+            'content_type' => $file['type'] ?? '',
+            'source' => $url,
+        ], fn($value) => $value !== '');
+    }
+
+    private function makeFileRef(string $relativePath, array $file): array
+    {
+        return array_filter([
+            'path' => $relativePath,
+            'name' => $file['ORIGINAL_NAME'] ?? $file['FILE_NAME'] ?? basename($relativePath),
+            'description' => $file['DESCRIPTION'] ?? '',
+            'content_type' => $file['CONTENT_TYPE'] ?? '',
+        ], fn($value) => $value !== '');
+    }
+
+    private function extractAttributeFileLinks(string $text): array
+    {
+        $links = [];
+        $attributes = [
+            'src',
+            'href',
+            'data-src',
+            'data-lazy-src',
+            'data-original',
+        ];
+
+        if (preg_match_all('/\b(' . implode('|', $attributes) . ')\s*=\s*([\'"])(.*?)\2/iu', $text, $matches)) {
+            foreach ($matches[3] as $link) {
+                $links[] = $this->normalizeExtractedLink($link);
+            }
+        }
+
+        return $links;
+    }
+
+    private function extractSrcsetFileLinks(string $text): array
+    {
+        $links = [];
+        $attributes = [
+            'srcset',
+            'data-srcset',
+        ];
+
+        if (preg_match_all('/\b(' . implode('|', $attributes) . ')\s*=\s*([\'"])(.*?)\2/iu', $text, $matches)) {
+            foreach ($matches[3] as $srcset) {
+                foreach (explode(',', html_entity_decode($srcset, ENT_QUOTES | ENT_HTML5)) as $candidate) {
+                    $parts = preg_split('/\s+/', trim($candidate));
+                    if (!empty($parts[0])) {
+                        $links[] = $parts[0];
+                    }
+                }
+            }
+        }
+
+        return $links;
+    }
+
+    private function extractCssFileLinks(string $text): array
+    {
+        $links = [];
+
+        if (preg_match_all('/url\(\s*(?:([\'"])(.*?)\1|([^)]*?))\s*\)/iu', $text, $matches, PREG_SET_ORDER)) {
+            foreach ($matches as $match) {
+                $links[] = $this->normalizeExtractedLink(($match[2] ?? '') !== '' ? $match[2] : ($match[3] ?? ''));
+            }
+        }
+
+        return $links;
+    }
+
+    private function normalizeExtractedLink(string $link): string
+    {
+        return trim(html_entity_decode($link, ENT_QUOTES | ENT_HTML5));
+    }
+
+    private function getLinkReplaceVariants(string $link): array
+    {
+        return array_values(array_unique(array_filter([
+            $link,
+            htmlspecialchars($link, ENT_QUOTES | ENT_HTML5),
+            htmlspecialchars($link, ENT_COMPAT | ENT_HTML5),
+        ])));
+    }
+
+    private function getLocalFilePath(array $file): string
+    {
+        if (empty($file['SRC'])) {
+            return '';
+        }
+
+        $src = (string)$file['SRC'];
+        if ($this->isUrl($src)) {
+            return '';
+        }
+
+        return Module::getDocRoot() . rawurldecode($src);
+    }
+
+    private function getFileUrl(array $file): string
+    {
+        if (empty($file['SRC'])) {
+            return '';
+        }
+
+        $src = (string)$file['SRC'];
+        return $this->isUrl($src) ? $src : '';
+    }
+
+    private function getFileIdByUploadPath(string $path): int
+    {
+        $path = rawurldecode(parse_url($path, PHP_URL_PATH) ?: '');
+        if (!str_starts_with($path, '/upload/')) {
+            return 0;
+        }
+
+        $relativePath = trim(substr($path, strlen('/upload/')), '/');
+        $subdir = trim(dirname($relativePath), '.');
+        $fileName = basename($relativePath);
+
+        if ($subdir === '' || $fileName === '') {
+            return 0;
+        }
+
+        $file = CFile::GetList(
+            ['ID' => 'DESC'],
+            [
+                'SUBDIR' => $subdir,
+                'FILE_NAME' => $fileName,
+            ]
+        )->Fetch();
+
+        return (int)($file['ID'] ?? 0);
+    }
+
+    private function isSupportedFileLink(string $link): bool
+    {
+        if ($this->isLocalUploadLink($link)) {
+            return true;
+        }
+
+        return $this->isCloudStorageLink($link);
+    }
+
+    private function isLocalUploadLink(string $link): bool
+    {
+        $path = parse_url($link, PHP_URL_PATH);
+        if (!is_string($path) || !str_starts_with($path, '/upload/')) {
+            return false;
+        }
+
+        $host = parse_url($link, PHP_URL_HOST);
+        if (!is_string($host) || $host === '') {
+            return true;
+        }
+
+        return $this->isLocalHost($host);
+    }
+
+    private function isLocalHost(string $host): bool
+    {
+        $host = $this->normalizeHost($host);
+        if ($host === '') {
+            return false;
+        }
+
+        foreach ($this->getLocalHosts() as $localHost) {
+            if ($host === $localHost) {
+                return true;
+            }
+
+            if (str_starts_with($localHost, '*.')) {
+                $suffix = substr($localHost, 2);
+                if ($host === $suffix || str_ends_with($host, '.' . $suffix)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function getLocalHosts(): array
+    {
+        if ($this->localHosts !== null) {
+            return $this->localHosts;
+        }
+
+        $hosts = [
+            $_SERVER['HTTP_HOST'] ?? '',
+            $_SERVER['SERVER_NAME'] ?? '',
+        ];
+
+        if (class_exists('\COption')) {
+            $hosts[] = \COption::GetOptionString('main', 'server_name', '');
+        }
+
+        if (class_exists('\CSite')) {
+            $by = 'sort';
+            $order = 'asc';
+            $dbres = \CSite::GetList($by, $order, []);
+            while ($site = $dbres->Fetch()) {
+                $hosts[] = $site['SERVER_NAME'] ?? '';
+                foreach (preg_split('/[\s,;]+/', (string)($site['DOMAINS'] ?? '')) as $domain) {
+                    $hosts[] = $domain;
+                }
+            }
+        }
+
+        $hosts = array_map(fn($host) => $this->normalizeHost((string)$host), $hosts);
+
+        $this->localHosts = array_values(array_unique(array_filter($hosts)));
+
+        return $this->localHosts;
+    }
+
+    private function normalizeHost(string $host): string
+    {
+        $host = trim(strtolower($host));
+        if ($host === '') {
+            return '';
+        }
+
+        if (str_contains($host, '://')) {
+            $host = (string)parse_url($host, PHP_URL_HOST);
+        }
+
+        return trim((string)preg_replace('/:\d+$/', '', $host), '.');
+    }
+
+    private function isCloudStorageLink(string $link): bool
+    {
+        if (!$this->isUrl($link)) {
+            return false;
+        }
+
+        if (!class_exists('\CCloudStorage') && class_exists('\CModule')) {
+            \CModule::IncludeModule('clouds');
+        }
+
+        if (!class_exists('\CCloudStorage') || !method_exists('\CCloudStorage', 'FindBucketByFile')) {
+            return false;
+        }
+
+        return is_object(\CCloudStorage::FindBucketByFile($link));
+    }
+
+    private function isUrl(string $value): bool
+    {
+        return str_starts_with($value, 'http://') || str_starts_with($value, 'https://');
+    }
+}

--- a/lib/exchange/reader.php
+++ b/lib/exchange/reader.php
@@ -81,7 +81,7 @@ class Reader
     {
         $attrs = $this->readAttributes();
 
-        if (!$attrs['exchangeVersion'] || $attrs['exchangeVersion'] < Module::EXCHANGE_VERSION) {
+        if (empty($attrs['exchangeVersion']) || (int)$attrs['exchangeVersion'] < Module::EXCHANGE_VERSION_LEGACY) {
             throw new HelperException(
                 Locale::getMessage('ERR_EXCHANGE_VERSION', ['#NAME#' => $this->file])
             );
@@ -95,6 +95,7 @@ class Reader
         $record = $this->getTagAttributes($reader);
         $record['fields'] = [];
         $record['properties'] = [];
+        $record['file_links'] = [];
 
         do {
             $reader->read();
@@ -103,6 +104,9 @@ class Reader
             }
             if ($this->isOpenTag($reader, 'property')) {
                 $record['properties'][] = $this->readRecordField($reader, 'property');
+            }
+            if ($this->isOpenTag($reader, 'file_links')) {
+                $record['file_links'][] = $this->readRecordField($reader, 'file_links');
             }
         } while (!$this->isCloseTag($reader, 'item'));
 
@@ -216,6 +220,9 @@ class Reader
         }
         if (!empty($attrs['description'])) {
             $file['description'] = $attrs['description'];
+        }
+        if (!empty($attrs['content_type'])) {
+            $file['type'] = $attrs['content_type'];
         }
         return $file;
     }

--- a/lib/exchange/restartablereader.php
+++ b/lib/exchange/restartablereader.php
@@ -7,6 +7,7 @@ use Sprint\Migration\Exceptions\MigrationException;
 use Sprint\Migration\Exceptions\RestartException;
 use Sprint\Migration\Interfaces\ReaderHelperInterface;
 use Sprint\Migration\Interfaces\RestartableInterface;
+use Sprint\Migration\Module;
 use Sprint\Migration\Output;
 
 class RestartableReader
@@ -71,12 +72,18 @@ class RestartableReader
 
     private function read(int $offset, Closure $userfunc, Closure $progressFn): int
     {
+        Module::prepareLongDatabaseConnection();
+
         $records = $this->helper->convertReaderRecords(
             $this->attributes,
             $this->reader->readRecords($offset, $this->limit)
         );
 
-        array_map($userfunc, $records);
+        foreach ($records as $record) {
+            Module::prepareLongDatabaseConnection();
+            $userfunc($record);
+            Module::reconnectDatabase();
+        }
 
         $readCount = count($records);
 

--- a/lib/exchange/restartablewriter.php
+++ b/lib/exchange/restartablewriter.php
@@ -6,6 +6,7 @@ use Closure;
 use Sprint\Migration\Exceptions\MigrationException;
 use Sprint\Migration\Exceptions\RestartException;
 use Sprint\Migration\Interfaces\RestartableInterface;
+use Sprint\Migration\Module;
 
 class RestartableWriter
 {
@@ -79,10 +80,14 @@ class RestartableWriter
      */
     private function write(int $offset, Closure $recordsFn, Closure $progressFn): int
     {
+        Module::prepareLongDatabaseConnection();
+
         /** @var WriterTag $tags */
-        $tags = $recordsFn($offset, $this->limit);
+        $tags = $recordsFn($offset, $this->limit, $this->directory);
 
         $fetchedCount = $this->writer->appendTagsToFile($tags);
+
+        Module::reconnectDatabase();
 
         $offset += $fetchedCount;
 

--- a/lib/exchange/writer.php
+++ b/lib/exchange/writer.php
@@ -71,13 +71,24 @@ class Writer
      */
     private function copyTagsFiles(WriterTag $tag): void
     {
+        $fileExchange = new FileExchange();
         foreach ($tag->getFiles() as $file) {
+            Module::prepareLongDatabaseConnection();
+
+            if (!empty($file['ID'])) {
+                $fileExchange->exportFileById((int)$file['ID'], $this->getFileDir(), '');
+                Module::reconnectDatabase();
+                continue;
+            }
+
             $filePath = Module::getDocRoot() . $file['SRC'];
             if (file_exists($filePath)) {
                 $newPath = $this->getFileDir() . '/' . $file['SUBDIR'] . '/' . $file['FILE_NAME'];
                 Module::createDir(dirname($newPath));
                 copy($filePath, $newPath);
             }
+
+            Module::reconnectDatabase();
         }
 
     }

--- a/lib/exchange/writertag.php
+++ b/lib/exchange/writertag.php
@@ -135,13 +135,35 @@ class WriterTag
         $this->addValueTag(
             $file['SUBDIR'] . '/' . $file['FILE_NAME'],
             [
-                'name'        => $file['ORIGINAL_NAME'],
-                'description' => $file['DESCRIPTION'],
-                'type'        => 'file',
+                'id'           => $file['ID'] ?? $fileId,
+                'name'         => $file['ORIGINAL_NAME'],
+                'description'  => $file['DESCRIPTION'],
+                'content_type' => $file['CONTENT_TYPE'] ?? '',
+                'type'         => 'file',
             ]
         );
 
         $this->files[] = $file;
+    }
+
+    public function addFileRefTag(array $fileRef, array $attributes = []): void
+    {
+        if (empty($fileRef['path'])) {
+            return;
+        }
+
+        $this->addValueTag(
+            $fileRef['path'],
+            array_merge(
+                [
+                    'name'         => $fileRef['name'] ?? '',
+                    'description'  => $fileRef['description'] ?? '',
+                    'content_type' => $fileRef['content_type'] ?? '',
+                    'type'         => 'file',
+                ],
+                $attributes
+            )
+        );
     }
 
     public function getFiles(): array

--- a/lib/helpers/bloghelper.php
+++ b/lib/helpers/bloghelper.php
@@ -835,7 +835,7 @@ class BlogHelper extends Helper
 
         $values = [];
 
-        foreach ($this->makeNonEmptyArray($value) as $fileRef) {
+        foreach ($this->makePostUserFieldFileRefs($value, $multiple) as $fileRef) {
             if (is_array($fileRef)) {
                 $file = $this->fileExchange->makeFileArrayByRef($fileRef, $exchangeDir);
                 if ($file) {
@@ -845,6 +845,15 @@ class BlogHelper extends Helper
         }
 
         return $multiple ? $values : ($values[0] ?? false);
+    }
+
+    protected function makePostUserFieldFileRefs(mixed $value, bool $multiple): array
+    {
+        if (!$multiple && is_array($value) && isset($value['path'])) {
+            return [$value];
+        }
+
+        return $this->makeNonEmptyArray($value);
     }
 
     protected function getPostUserField(string $fieldName): array

--- a/lib/helpers/bloghelper.php
+++ b/lib/helpers/bloghelper.php
@@ -9,22 +9,23 @@ use CBlogImage;
 use CBlogPost;
 use CBlogPostCategory;
 use CBlogUserGroup;
-use CFile;
 use CUserFieldEnum;
 use CUserTypeEntity;
 use Sprint\Migration\Exceptions\HelperException;
+use Sprint\Migration\Exchange\FileExchange;
 use Sprint\Migration\Helper;
 use Sprint\Migration\Locale;
-use Sprint\Migration\Module;
 
 class BlogHelper extends Helper
 {
 
     private UserHelper $userHelper;
+    private FileExchange $fileExchange;
 
     public function __construct()
     {
         $this->userHelper = new UserHelper();
+        $this->fileExchange = new FileExchange();
     }
 
     public function isEnabled(): bool
@@ -172,7 +173,7 @@ class BlogHelper extends Helper
         $post['CATEGORIES'] = $this->exportPostCategories((int)$post['BLOG_ID'], (int)$post['ID']);
         $post['PERMS_POST'] = $this->exportPostPerms((int)$post['BLOG_ID'], (int)$post['ID'], BLOG_PERMS_POST);
         $post['PERMS_COMMENT'] = $this->exportPostPerms((int)$post['BLOG_ID'], (int)$post['ID'], BLOG_PERMS_COMMENT);
-        $post['ATTACH_IMG'] = $this->exportFileRef((int)$post['ATTACH_IMG'], $exchangeDir, 'blog_post_files');
+        $post['ATTACH_IMG'] = $this->fileExchange->exportFileById((int)$post['ATTACH_IMG'], $exchangeDir, 'blog_post_files');
         $post['UF_VALUES'] = $this->exportPostUserFields((int)$post['ID'], $exchangeDir);
         $post['TEXT_IMAGES'] = $this->exportPostTextImages($post, $exchangeDir);
 
@@ -516,10 +517,7 @@ class BlogHelper extends Helper
 
     protected function prepareGroupFields(array $fields): array
     {
-        return array_intersect_key(
-            $fields,
-            array_flip(array_keys($this->getDefaultGroup()))
-        );
+        return array_intersect_key($fields, $this->getDefaultGroup());
     }
 
     /**
@@ -540,7 +538,7 @@ class BlogHelper extends Helper
         if (!$hasAttachImg) {
             unset($fields['ATTACH_IMG']);
         } elseif (!empty($fields['ATTACH_IMG']) && is_array($fields['ATTACH_IMG'])) {
-            $fields['ATTACH_IMG'] = $this->makeFileArrayByRef($fields['ATTACH_IMG'], $exchangeDir);
+            $fields['ATTACH_IMG'] = $this->fileExchange->makeFileArrayByRef($fields['ATTACH_IMG'], $exchangeDir);
         }
 
         $this->unsetKeys($fields, [
@@ -758,7 +756,7 @@ class BlogHelper extends Helper
 
             $values = array_filter($this->makeNonEmptyArray($value));
             $items = array_map(
-                fn($fileId) => $this->exportFileRef((int)$fileId, $exchangeDir, 'blog_post_files'),
+                fn($fileId) => $this->fileExchange->exportFileById((int)$fileId, $exchangeDir, 'blog_post_files'),
                 $values
             );
             $items = array_values(array_filter($items));
@@ -839,7 +837,7 @@ class BlogHelper extends Helper
 
         foreach ($this->makeNonEmptyArray($value) as $fileRef) {
             if (is_array($fileRef)) {
-                $file = $this->makeFileArrayByRef($fileRef, $exchangeDir);
+                $file = $this->fileExchange->makeFileArrayByRef($fileRef, $exchangeDir);
                 if ($file) {
                     $values[] = $file;
                 }
@@ -887,56 +885,6 @@ class BlogHelper extends Helper
         return $result;
     }
 
-    protected function exportFileRef(int $fileId, string $exchangeDir = '', string $subdir = 'files'): array|false
-    {
-        if (!$fileId || $exchangeDir === '') {
-            return false;
-        }
-
-        $file = CFile::GetFileArray($fileId);
-        if (empty($file['SRC'])) {
-            return false;
-        }
-
-        $source = Module::getDocRoot() . $file['SRC'];
-        if (!is_file($source)) {
-            return false;
-        }
-
-        $relativePath = trim($subdir . '/' . $file['SUBDIR'] . '/' . $file['FILE_NAME'], '/');
-        $target = rtrim($exchangeDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $relativePath;
-        Module::createDir(dirname($target));
-        copy($source, $target);
-
-        return [
-            'path'        => $relativePath,
-            'name'        => $file['ORIGINAL_NAME'] ?? $file['FILE_NAME'],
-            'description' => $file['DESCRIPTION'] ?? '',
-        ];
-    }
-
-    protected function makeFileArrayByRef(array $fileRef, string $exchangeDir = ''): array|false
-    {
-        if (empty($fileRef['path']) || $exchangeDir === '') {
-            return false;
-        }
-
-        $path = rtrim($exchangeDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . ltrim($fileRef['path'], DIRECTORY_SEPARATOR);
-        $file = CFile::MakeFileArray($path);
-        if (empty($file)) {
-            return false;
-        }
-
-        if (!empty($fileRef['name'])) {
-            $file['name'] = $fileRef['name'];
-        }
-        if (!empty($fileRef['description'])) {
-            $file['description'] = $fileRef['description'];
-        }
-
-        return $file;
-    }
-
     protected function exportPostTextImages(array $post, string $exchangeDir = ''): array
     {
         $texts = [
@@ -972,7 +920,7 @@ class BlogHelper extends Helper
                 continue;
             }
 
-            $file = $this->exportFileRef((int)$image['FILE_ID'], $exchangeDir, 'blog_post_text_images');
+            $file = $this->fileExchange->exportFileById((int)$image['FILE_ID'], $exchangeDir, 'blog_post_text_images');
             if ($file) {
                 $result[$imageId] = [
                     'FILE'       => $file,
@@ -988,74 +936,7 @@ class BlogHelper extends Helper
 
     protected function exportPostTextFileLinks(array $texts, string $exchangeDir = ''): array
     {
-        $links = [];
-        foreach ($texts as $text) {
-            foreach ($this->extractLocalUploadLinks((string)$text) as $link) {
-                $file = $this->exportLocalFileRef($link, $exchangeDir, 'blog_post_text_links');
-                if ($file) {
-                    $links[$link] = $file;
-                }
-            }
-        }
-
-        return $links;
-    }
-
-    protected function extractLocalUploadLinks(string $text): array
-    {
-        $links = [];
-
-        if (preg_match_all('/<img\b[^>]*\bsrc\s*=\s*([\'"])(.*?)\1/iu', $text, $matches)) {
-            foreach ($matches[2] as $link) {
-                $links[] = html_entity_decode($link, ENT_QUOTES | ENT_HTML5);
-            }
-        }
-
-        if (preg_match_all('/\[IMG\]([^\[]+)\[\/IMG\]/iu', $text, $matches)) {
-            foreach ($matches[1] as $link) {
-                $links[] = trim($link);
-            }
-        }
-
-        return array_values(array_unique(array_filter(
-            $links,
-            fn($link) => $this->isLocalUploadLink((string)$link)
-        )));
-    }
-
-    protected function isLocalUploadLink(string $link): bool
-    {
-        $path = parse_url($link, PHP_URL_PATH);
-        return is_string($path) && str_starts_with($path, '/upload/');
-    }
-
-    protected function exportLocalFileRef(string $link, string $exchangeDir = '', string $subdir = 'files'): array|false
-    {
-        if ($exchangeDir === '') {
-            return false;
-        }
-
-        $path = parse_url($link, PHP_URL_PATH);
-        if (!is_string($path) || !str_starts_with($path, '/upload/')) {
-            return false;
-        }
-
-        $source = Module::getDocRoot() . rawurldecode($path);
-        if (!is_file($source)) {
-            return false;
-        }
-
-        $fileName = basename($source);
-        $relativePath = trim($subdir . '/' . md5($path) . '_' . $fileName, '/');
-        $target = rtrim($exchangeDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $relativePath;
-        Module::createDir(dirname($target));
-        copy($source, $target);
-
-        return [
-            'path'   => $relativePath,
-            'name'   => $fileName,
-            'source' => $link,
-        ];
+        return $this->fileExchange->exportTextFileLinks($texts, $exchangeDir, 'blog_post_text_links');
     }
 
     /**
@@ -1097,7 +978,7 @@ class BlogHelper extends Helper
 
         foreach ($updates as $fieldName => $text) {
             $text = $this->replacePostBlogImageIds($text, $imageMap);
-            $text = str_replace(array_keys($linkMap), array_values($linkMap), $text);
+            $text = $this->fileExchange->replaceTextFileLinks($text, $linkMap);
             $updates[$fieldName] = $text;
         }
 
@@ -1128,7 +1009,7 @@ class BlogHelper extends Helper
                 continue;
             }
 
-            $file = $this->makeFileArrayByRef($image['FILE'], $exchangeDir);
+            $file = $this->fileExchange->makeFileArrayByRef($image['FILE'], $exchangeDir);
             if (!$file) {
                 continue;
             }
@@ -1203,33 +1084,17 @@ class BlogHelper extends Helper
                 continue;
             }
 
-            $newLink = $this->restoreFileRefToUpload($fileRef, $exchangeDir, 'sprint_migration/blog_post_text');
+            $newLink = $this->fileExchange->saveFileRefAndGetPath(
+                $fileRef,
+                $exchangeDir,
+                'sprint_migration/blog_post_text'
+            );
             if ($newLink) {
                 $result[$oldLink] = $newLink;
             }
         }
 
         return $result;
-    }
-
-    protected function restoreFileRefToUpload(array $fileRef, string $exchangeDir = '', string $subdir = 'sprint_migration'): string
-    {
-        if (empty($fileRef['path']) || $exchangeDir === '') {
-            return '';
-        }
-
-        $source = rtrim($exchangeDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . ltrim($fileRef['path'], DIRECTORY_SEPARATOR);
-        if (!is_file($source)) {
-            return '';
-        }
-
-        $fileName = basename($fileRef['name'] ?? $source);
-        $relativePath = '/upload/' . trim($subdir, '/') . '/' . md5((string)$fileRef['path']) . '_' . $fileName;
-        $target = Module::getDocRoot() . $relativePath;
-        Module::createDir(dirname($target));
-        copy($source, $target);
-
-        return $relativePath;
     }
 
     protected function exportPostCategories(int $blogId, int $postId): array

--- a/lib/helpers/formhelper.php
+++ b/lib/helpers/formhelper.php
@@ -9,6 +9,7 @@ use CFormStatus;
 use CFormValidator;
 use Exception;
 use Sprint\Migration\Exceptions\HelperException;
+use Sprint\Migration\Exchange\FileExchange;
 use Sprint\Migration\Helper;
 use Sprint\Migration\Locale;
 use Sprint\Migration\Tables\FormGroupTable;
@@ -33,13 +34,14 @@ class FormHelper extends Helper
     /**
      * @throws HelperException
      */
-    public function exportFormById(int $formId): array
+    public function exportFormById(int $formId, string $exchangeDir = ''): array
     {
         $form = $this->export(
             $this->getFormById($formId),
             $this->getDefaultForm(),
             $this->getUnsetKeysForm()
         );
+        $form = $this->exportImageField($form, $exchangeDir, 'form_images');
 
         $form['arSITE'] = $this->exportSites($formId);
 
@@ -90,11 +92,12 @@ class FormHelper extends Helper
     /**
      * @throws HelperException
      */
-    public function saveForm(array $form): int
+    public function saveForm(array $form, string $exchangeDir = ''): int
     {
         $this->checkRequiredKeys($form, ['SID']);
 
         $form = $this->merge($form, $this->getDefaultForm());
+        $form = $this->prepareImageField($form, $exchangeDir);
 
         $form['VARNAME'] = $form['SID'];
 
@@ -138,13 +141,13 @@ class FormHelper extends Helper
      * @noinspection PhpUnused
      * @throws HelperException
      */
-    public function saveField(int $formId, array $field): int
+    public function saveField(int $formId, array $field, string $exchangeDir = ''): int
     {
         $this->checkRequiredKeys($field, ['SID']);
 
         $fieldId = $this->getFormFieldIdBySid($formId, $field['SID']);
 
-        return $this->replaceField($formId, $fieldId, $field);
+        return $this->replaceField($formId, $fieldId, $field, $exchangeDir);
     }
 
     public function getFormFieldIdBySid(int $formId, string $fieldSid)
@@ -156,16 +159,20 @@ class FormHelper extends Helper
     /**
      * @throws HelperException
      */
-    public function saveFields(int $formId, array $fields): array
+    public function saveFields(int $formId, array $fields, string $exchangeDir = ''): array
     {
-        return $this->updateFields($formId, $fields, true);
+        return $this->updateFields($formId, $fields, true, $exchangeDir);
     }
 
     /**
      * @throws HelperException
      */
-    public function updateFields(int $formId, array $fields, bool $deleteOldFields = false): array
-    {
+    public function updateFields(
+        int $formId,
+        array $fields,
+        bool $deleteOldFields = false,
+        string $exchangeDir = ''
+    ): array {
         $currentIdsBySid = [];
         foreach ($this->getFormFields($formId) as $currentField) {
             $currentIdsBySid[$currentField['SID']] = $currentField['ID'];
@@ -178,7 +185,7 @@ class FormHelper extends Helper
 
             $fieldId = $currentIdsBySid[$field['SID']] ?? 0;
 
-            $updatedIds[] = $this->replaceField($formId, $fieldId, $field);
+            $updatedIds[] = $this->replaceField($formId, $fieldId, $field, $exchangeDir);
         }
 
         if ($deleteOldFields) {
@@ -434,9 +441,9 @@ class FormHelper extends Helper
         return $fields;
     }
 
-    public function exportFormFields(int $formId, array $fieldSids = []): array
+    public function exportFormFields(int $formId, array $fieldSids = [], string $exchangeDir = ''): array
     {
-        return array_map(function ($field) {
+        return array_map(function ($field) use ($exchangeDir) {
             $field['ANSWERS'] = $this->exportCollection(
                 $this->getFieldAnswers($field['ID']),
                 $this->getDefaultAnswer(),
@@ -448,11 +455,13 @@ class FormHelper extends Helper
                 $this->getUnsetKeysValidator(),
             );
 
-            return $this->export(
+            $field = $this->export(
                 $field,
                 $this->getDefaultField(),
                 $this->getUnsetKeysField(),
             );
+
+            return $this->exportImageField($field, $exchangeDir, 'form_field_images');
         }, $this->getFormFields($formId, $fieldSids));
     }
 
@@ -613,9 +622,10 @@ class FormHelper extends Helper
     /**
      * @throws HelperException
      */
-    private function replaceField(int $formId, int $fieldId, array $field): int
+    private function replaceField(int $formId, int $fieldId, array $field, string $exchangeDir = ''): int
     {
         $field = $this->merge($field, $this->getDefaultField());
+        $field = $this->prepareImageField($field, $exchangeDir);
 
         $field['FORM_ID'] = $formId;
         $field['VARNAME'] = $field['SID'];
@@ -654,6 +664,33 @@ class FormHelper extends Helper
 
         $this->outNotice($fieldId ? "Form field $newId updated" : "Form field $newId created");
         return $newId;
+    }
+
+    private function exportImageField(array $fields, string $exchangeDir, string $subdir): array
+    {
+        if (!empty($fields['IMAGE_ID']) && is_numeric($fields['IMAGE_ID'])) {
+            $fileRef = (new FileExchange())->exportFileById((int)$fields['IMAGE_ID'], $exchangeDir, $subdir);
+            if ($fileRef) {
+                $fields['IMAGE_ID'] = $fileRef;
+            }
+        }
+
+        return $fields;
+    }
+
+    private function prepareImageField(array $fields, string $exchangeDir): array
+    {
+        if (!empty($fields['IMAGE_ID']) && is_array($fields['IMAGE_ID'])) {
+            $file = (new FileExchange())->makeFileArrayByRef($fields['IMAGE_ID'], $exchangeDir);
+            if ($file) {
+                $file['MODULE_ID'] = 'form';
+                $fields['arIMAGE'] = $file;
+            }
+
+            unset($fields['IMAGE_ID']);
+        }
+
+        return $fields;
     }
 
     private function getUnsetKeysForm(): array

--- a/lib/helpers/hlblockexchangehelper.php
+++ b/lib/helpers/hlblockexchangehelper.php
@@ -3,10 +3,12 @@
 namespace Sprint\Migration\Helpers;
 
 use Sprint\Migration\Exceptions\HelperException;
+use Sprint\Migration\Exchange\FileExchange;
 use Sprint\Migration\Exchange\WriterTag;
 use Sprint\Migration\Interfaces\ReaderHelperInterface;
 use Sprint\Migration\Interfaces\WriterHelperInterface;
 use Sprint\Migration\Locale;
+use Sprint\Migration\Module;
 
 class HlblockExchangeHelper extends HlblockHelper implements ReaderHelperInterface, WriterHelperInterface
 {
@@ -71,6 +73,8 @@ class HlblockExchangeHelper extends HlblockHelper implements ReaderHelperInterfa
      */
     protected function convertReaderRecord(int $hlblockId, array $record): array
     {
+        $fileLinks = $this->groupReaderFileLinks($record['file_links'] ?? []);
+
         $convertedFields = [];
         foreach ($record['fields'] as $field) {
             $fieldType = $this->getFieldType($hlblockId, $field['name']);
@@ -83,6 +87,12 @@ class HlblockExchangeHelper extends HlblockHelper implements ReaderHelperInterfa
                 $convertedFields[$field['name']] = $this->readFieldIblockSection($hlblockId, $field);
             } elseif ($fieldType == 'hlblock') {
                 $convertedFields[$field['name']] = $this->readFieldHlblockElement($hlblockId, $field);
+            } elseif ($this->isTextFileLinksFieldType($fieldType)) {
+                $convertedFields[$field['name']] = $this->readFieldTextFileLinks(
+                    $hlblockId,
+                    $field,
+                    $fileLinks['field'][$field['name']] ?? []
+                );
             } else {
                 $convertedFields[$field['name']] = $this->readFieldValue($hlblockId, $field);
             }
@@ -91,6 +101,32 @@ class HlblockExchangeHelper extends HlblockHelper implements ReaderHelperInterfa
             'hlblock_id' => $hlblockId,
             'fields'     => $convertedFields,
         ];
+    }
+
+    protected function groupReaderFileLinks(array $items): array
+    {
+        $result = [];
+
+        foreach ($items as $item) {
+            $scope = (string)($item['scope'] ?? '');
+            $name = (string)($item['name'] ?? '');
+            $index = (int)($item['index'] ?? 0);
+
+            if ($scope === '' || $name === '') {
+                continue;
+            }
+
+            foreach (($item['value'] ?? []) as $value) {
+                $source = (string)($value['source'] ?? '');
+                if ($source === '' || empty($value['value']) || !is_array($value['value'])) {
+                    continue;
+                }
+
+                $result[$scope][$name][$index][$source] = $value['value'];
+            }
+        }
+
+        return $result;
     }
 
     /**
@@ -107,6 +143,63 @@ class HlblockExchangeHelper extends HlblockHelper implements ReaderHelperInterfa
         } else {
             return $field['value'][0]['value'];
         }
+    }
+
+    /**
+     * @throws HelperException
+     */
+    protected function readFieldTextFileLinks(int $hlblockId, array $field, array $fileLinks = []): mixed
+    {
+        $value = $this->readFieldValue($hlblockId, $field);
+        if (empty($fileLinks)) {
+            return $value;
+        }
+
+        if ($this->isFieldMultiple($hlblockId, $field['name'])) {
+            $values = array_values((array)$value);
+            foreach ($values as $index => $item) {
+                if (!empty($fileLinks[$index])) {
+                    $values[$index] = $this->importFieldTextFileLinks($item, $fileLinks[$index]);
+                }
+            }
+            return $values;
+        }
+
+        return $this->importFieldTextFileLinks($value, $fileLinks[0] ?? []);
+    }
+
+    protected function importFieldTextFileLinks(mixed $value, array $fileLinks = []): mixed
+    {
+        if (empty($fileLinks)) {
+            return $value;
+        }
+
+        $isFormatted = is_array($value) && (array_key_exists('TEXT', $value) || array_key_exists('TYPE', $value));
+        $text = $isFormatted ? (string)($value['TEXT'] ?? '') : (string)$value;
+
+        $linkMap = [];
+        foreach ($fileLinks as $oldLink => $fileRef) {
+            if (!is_array($fileRef)) {
+                continue;
+            }
+
+            Module::prepareLongDatabaseConnection();
+            $fileId = \CFile::SaveFile($fileRef, 'sprint_migration/hlblock_text');
+            Module::reconnectDatabase();
+
+            if ($fileId) {
+                $linkMap[$oldLink] = (string)\CFile::GetPath($fileId);
+            }
+        }
+
+        $text = (new FileExchange())->replaceTextFileLinks($text, $linkMap);
+
+        if ($isFormatted) {
+            $value['TEXT'] = $text;
+            return $value;
+        }
+
+        return $text;
     }
 
     /**
@@ -243,6 +336,7 @@ class HlblockExchangeHelper extends HlblockHelper implements ReaderHelperInterfa
     public function getWriterRecordsTag(int $offset, int $limit, ...$vars): WriterTag
     {
         [$hlblockId, $filter, $exportFields] = $vars;
+        $exchangeDir = (string)($vars[3] ?? '');
 
         $elements = $this->getElements(
             $hlblockId,
@@ -260,7 +354,8 @@ class HlblockExchangeHelper extends HlblockHelper implements ReaderHelperInterfa
                 $this->createWriterRecordTag(
                     $hlblockId,
                     $element,
-                    $exportFields
+                    $exportFields,
+                    $exchangeDir
                 )
             );
         }
@@ -271,23 +366,35 @@ class HlblockExchangeHelper extends HlblockHelper implements ReaderHelperInterfa
     /**
      * @throws HelperException
      */
-    protected function createWriterRecordTag($hlblockId, array $element, array $exportFields): WriterTag
-    {
+    protected function createWriterRecordTag(
+        $hlblockId,
+        array $element,
+        array $exportFields,
+        string $exchangeDir = ''
+    ): WriterTag {
         $item = new WriterTag('item');
 
         foreach ($element as $code => $val) {
             if (in_array($code, $exportFields)) {
-                $item->addChild(
-                    $this->createWriterFieldTag(
-                        array_merge(
-                            $this->getField($hlblockId, $code),
-                            [
-                                'HLBLOCK_ID' => $hlblockId,
-                                'VALUE'      => $val,
-                            ]
-                        )
-                    )
+                $field = array_merge(
+                    $this->getField($hlblockId, $code),
+                    [
+                        'HLBLOCK_ID' => $hlblockId,
+                        'VALUE'      => $val,
+                    ]
                 );
+
+                $item->addChild(
+                    $this->createWriterFieldTag($field)
+                );
+
+                if (
+                    Module::EXCHANGE_VERSION > Module::EXCHANGE_VERSION_LEGACY
+                    && $exchangeDir !== ''
+                    && $this->isTextFileLinksFieldType((string)$field['USER_TYPE_ID'])
+                ) {
+                    $this->addTextFileLinksTags($item, $field, $exchangeDir);
+                }
             }
         }
         return $item;
@@ -315,6 +422,64 @@ class HlblockExchangeHelper extends HlblockHelper implements ReaderHelperInterfa
         }
 
         return $tag;
+    }
+
+    protected function addTextFileLinksTags(WriterTag $item, array $field, string $exchangeDir): void
+    {
+        $multiple = (($field['MULTIPLE'] ?? 'N') === 'Y');
+        $values = $multiple ? array_values((array)$field['VALUE']) : [$field['VALUE']];
+
+        foreach ($values as $index => $value) {
+            $text = $this->normalizeTextFieldValue($value);
+            if ($text === '') {
+                continue;
+            }
+
+            $fileLinks = (new FileExchange())->exportTextFileLinks(
+                $text,
+                $exchangeDir,
+                'hlblock_text'
+            );
+
+            if (empty($fileLinks)) {
+                continue;
+            }
+
+            $tag = new WriterTag('file_links', [
+                'scope' => 'field',
+                'name'  => $field['FIELD_NAME'],
+                'index' => $index,
+            ]);
+
+            foreach ($fileLinks as $source => $fileRef) {
+                $tag->addFileRefTag($fileRef, ['source' => $source]);
+            }
+
+            $item->addChild($tag);
+        }
+    }
+
+    protected function normalizeTextFieldValue(mixed $value): string
+    {
+        if (is_array($value)) {
+            return $this->decodeHtmlValue((string)($value['TEXT'] ?? ''));
+        }
+
+        return $this->decodeHtmlValue((string)$value);
+    }
+
+    protected function decodeHtmlValue(string $value): string
+    {
+        if (function_exists('htmlspecialcharsback')) {
+            return htmlspecialcharsback($value);
+        }
+
+        return html_entity_decode($value, ENT_QUOTES | ENT_HTML5);
+    }
+
+    protected function isTextFileLinksFieldType(string $fieldType): bool
+    {
+        return in_array($fieldType, ['string', 'html', 'string_formatted']);
     }
 
     /**

--- a/lib/helpers/iblockexchangehelper.php
+++ b/lib/helpers/iblockexchangehelper.php
@@ -4,9 +4,11 @@ namespace Sprint\Migration\Helpers;
 
 use _CIBElement;
 use Sprint\Migration\Exceptions\HelperException;
+use Sprint\Migration\Exchange\FileExchange;
 use Sprint\Migration\Exchange\WriterTag;
 use Sprint\Migration\Interfaces\ReaderHelperInterface;
 use Sprint\Migration\Interfaces\WriterHelperInterface;
+use Sprint\Migration\Module;
 
 class IblockExchangeHelper extends IblockHelper implements ReaderHelperInterface, WriterHelperInterface
 {
@@ -123,7 +125,12 @@ class IblockExchangeHelper extends IblockHelper implements ReaderHelperInterface
      */
     public function getWriterRecordsTag(int $offset, int $limit, ...$vars): WriterTag
     {
-        [$iblockId, $filter, $exportFields, $exportProps] = $vars;
+        [$iblockId, $filter, $exportFields, $exportProps, $exchangeDir] = array_pad($vars, 5, '');
+
+        $select = array_values(array_unique(array_merge(
+            ['ID', 'IBLOCK_ID'],
+            array_diff($exportFields, ['IBLOCK_SECTION', 'IPROPERTY_TEMPLATES'])
+        )));
 
         $dbres = $this->getElementsList(
             $iblockId,
@@ -132,6 +139,7 @@ class IblockExchangeHelper extends IblockHelper implements ReaderHelperInterface
                 'offset' => $offset,
                 'limit'  => $limit,
                 'filter' => $filter,
+                'select' => $select,
             ]
         );
 
@@ -143,7 +151,8 @@ class IblockExchangeHelper extends IblockHelper implements ReaderHelperInterface
                     $this->getElementFields($element),
                     $this->getElementProps($element),
                     $exportFields,
-                    $exportProps
+                    $exportProps,
+                    (string)$exchangeDir
                 )
             );
         }
@@ -194,18 +203,36 @@ class IblockExchangeHelper extends IblockHelper implements ReaderHelperInterface
         array $fields,
         array $props,
         array $exportFields,
-        array $exportProperties
+        array $exportProperties,
+        string $exchangeDir = ''
     ): WriterTag {
         $item = new WriterTag('item');
 
-        foreach ($fields as $code => $val) {
-            if (in_array($code, $exportFields)) {
-                $item->addChild(
-                    $this->createWriterFieldTag([
-                        'NAME'      => $code,
-                        'VALUE'     => $val,
-                        'IBLOCK_ID' => $iblockId,
-                    ])
+        foreach ($exportFields as $code) {
+            if (!array_key_exists($code, $fields) && !array_key_exists('~' . $code, $fields)) {
+                continue;
+            }
+
+            $val = $this->getWriterFieldValueForExport($code, $fields);
+            $item->addChild(
+                $this->createWriterFieldTag([
+                    'NAME'      => $code,
+                    'VALUE'     => $val,
+                    'IBLOCK_ID' => $iblockId,
+                ])
+            );
+
+            if (
+                Module::EXCHANGE_VERSION > Module::EXCHANGE_VERSION_LEGACY
+                && $exchangeDir !== ''
+                && in_array($code, ['PREVIEW_TEXT', 'DETAIL_TEXT'])
+            ) {
+                $this->addTextFileLinksTag(
+                    $item,
+                    'field',
+                    $code,
+                    (string)$val,
+                    $exchangeDir
                 );
             }
         }
@@ -215,10 +242,120 @@ class IblockExchangeHelper extends IblockHelper implements ReaderHelperInterface
                 $item->addChild(
                     $this->createWriterPropertyTag($prop)
                 );
+
+                if (
+                    Module::EXCHANGE_VERSION > Module::EXCHANGE_VERSION_LEGACY
+                    && $exchangeDir !== ''
+                    && $prop['PROPERTY_TYPE'] == 'S'
+                    && $prop['USER_TYPE'] == 'HTML'
+                ) {
+                    $this->addPropertyHtmlFileLinksTags($item, $prop, $exchangeDir);
+                }
             }
         }
 
         return $item;
+    }
+
+    protected function getWriterFieldValueForExport(string $code, array $fields): mixed
+    {
+        $value = $fields['~' . $code] ?? $fields[$code] ?? null;
+
+        if (in_array($code, ['PREVIEW_TEXT', 'DETAIL_TEXT'])) {
+            $type = (string)($fields[$code . '_TYPE'] ?? $fields['~' . $code . '_TYPE'] ?? '');
+            if (strtolower($type) == 'html' && !array_key_exists('~' . $code, $fields)) {
+                return $this->decodeHtmlValue((string)$value);
+            }
+        }
+
+        return $value;
+    }
+
+    protected function decodeHtmlValue(string $value): string
+    {
+        if (function_exists('htmlspecialcharsback')) {
+            return htmlspecialcharsback($value);
+        }
+
+        return html_entity_decode($value, ENT_QUOTES | ENT_HTML5);
+    }
+
+    protected function addTextFileLinksTag(
+        WriterTag $item,
+        string $scope,
+        string $name,
+        string $text,
+        string $exchangeDir,
+        int $index = 0
+    ): void {
+        $fileLinks = (new FileExchange())->exportTextFileLinks(
+            $text,
+            $exchangeDir,
+            'iblock_element_text'
+        );
+
+        if (empty($fileLinks)) {
+            return;
+        }
+
+        $tag = new WriterTag('file_links', [
+            'scope' => $scope,
+            'name'  => $name,
+            'index' => $index,
+        ]);
+
+        foreach ($fileLinks as $source => $fileRef) {
+            $tag->addFileRefTag($fileRef, ['source' => $source]);
+        }
+
+        $item->addChild($tag);
+    }
+
+    protected function addPropertyHtmlFileLinksTags(WriterTag $item, array $prop, string $exchangeDir): void
+    {
+        if ($prop['MULTIPLE'] == 'Y') {
+            foreach ($this->getPropertyHtmlValues($prop) as $index => $value) {
+                $htmlValue = $this->normalizeHtmlPropertyValue($value);
+                $this->addTextFileLinksTag(
+                    $item,
+                    'property',
+                    $prop['CODE'],
+                    $htmlValue['TEXT'],
+                    $exchangeDir,
+                    $index
+                );
+            }
+            return;
+        }
+
+        $htmlValue = $this->normalizeHtmlPropertyValue($prop['VALUE']);
+        $this->addTextFileLinksTag(
+            $item,
+            'property',
+            $prop['CODE'],
+            $htmlValue['TEXT'],
+            $exchangeDir
+        );
+    }
+
+    protected function normalizeHtmlPropertyValue(mixed $value): array
+    {
+        if (is_array($value)) {
+            return [
+                'TEXT' => $this->decodeHtmlValue((string)($value['TEXT'] ?? '')),
+                'TYPE' => (string)($value['TYPE'] ?? 'html'),
+            ];
+        }
+
+        return [
+            'TEXT' => $this->decodeHtmlValue((string)$value),
+            'TYPE' => 'html',
+        ];
+    }
+
+    protected function getPropertyHtmlValues(array $prop): array
+    {
+        return array_values(is_array($prop['VALUE']) ? $prop['VALUE'] : [$prop['VALUE']]);
     }
 
     /**
@@ -296,20 +433,22 @@ class IblockExchangeHelper extends IblockHelper implements ReaderHelperInterface
     protected function writePropertyHtml(WriterTag $tag, $prop): void
     {
         if ($prop['MULTIPLE'] == 'Y') {
-            foreach ($prop['VALUE'] as $index => $val1) {
+            foreach ($this->getPropertyHtmlValues($prop) as $index => $val1) {
+                $htmlValue = $this->normalizeHtmlPropertyValue($val1);
                 $tag->addValueTag(
-                    $val1['TEXT'],
+                    $htmlValue['TEXT'],
                     [
-                        'text-type'   => $val1['TYPE'],
+                        'text-type'   => $htmlValue['TYPE'],
                         'description' => $prop['DESCRIPTION'][$index] ?? '',
                     ]
                 );
             }
         } else {
+            $htmlValue = $this->normalizeHtmlPropertyValue($prop['VALUE']);
             $tag->addValueTag(
-                $prop['VALUE']['TEXT'] ?? '',
+                $htmlValue['TEXT'],
                 [
-                    'text-type'   => $prop['VALUE']['TYPE'] ?? '',
+                    'text-type'   => $htmlValue['TYPE'],
                     'description' => $prop['DESCRIPTION'],
                 ]
             );
@@ -396,12 +535,19 @@ class IblockExchangeHelper extends IblockHelper implements ReaderHelperInterface
      */
     protected function convertReaderRecord(int $iblockId, array $record): array
     {
+        $fileLinks = $this->groupReaderFileLinks($record['file_links'] ?? []);
+
         $convertedFields = [];
         foreach ($record['fields'] as $field) {
             if ($field['name'] == 'IBLOCK_SECTION') {
                 $convertedFields[$field['name']] = $this->readFieldSection($iblockId, $field);
             } elseif ($field['name'] == 'IPROPERTY_TEMPLATES') {
                 $convertedFields[$field['name']] = $this->readFieldIpropertyTemplates($field);
+            } elseif (in_array($field['name'], ['PREVIEW_TEXT', 'DETAIL_TEXT'])) {
+                $convertedFields[$field['name']] = $this->importXmlTextFileLinks(
+                    $this->readFieldValue($field),
+                    $fileLinks['field'][$field['name']][0] ?? []
+                );
             } else {
                 $convertedFields[$field['name']] = $this->readFieldValue($field);
             }
@@ -421,7 +567,11 @@ class IblockExchangeHelper extends IblockHelper implements ReaderHelperInterface
             } elseif ($propType == 'E') {
                 $convertedProperties[$prop['name']] = $this->readPropertyElement($iblockId, $prop);
             } elseif ($propType == 'S' && $userType == 'HTML') {
-                $convertedProperties[$prop['name']] = $this->readPropertyHtml($iblockId, $prop);
+                $convertedProperties[$prop['name']] = $this->readPropertyHtml(
+                    $iblockId,
+                    $prop,
+                    $fileLinks['property'][$prop['name']] ?? []
+                );
             } else {
                 $convertedProperties[$prop['name']] = $this->readPropertyString($iblockId, $prop);
             }
@@ -432,6 +582,32 @@ class IblockExchangeHelper extends IblockHelper implements ReaderHelperInterface
             'fields'     => $convertedFields,
             'properties' => $convertedProperties,
         ];
+    }
+
+    protected function groupReaderFileLinks(array $items): array
+    {
+        $result = [];
+
+        foreach ($items as $item) {
+            $scope = (string)($item['scope'] ?? '');
+            $name = (string)($item['name'] ?? '');
+            $index = (int)($item['index'] ?? 0);
+
+            if ($scope === '' || $name === '') {
+                continue;
+            }
+
+            foreach (($item['value'] ?? []) as $value) {
+                $source = (string)($value['source'] ?? '');
+                if ($source === '' || empty($value['value']) || !is_array($value['value'])) {
+                    continue;
+                }
+
+                $result[$scope][$name][$index][$source] = $value['value'];
+            }
+        }
+
+        return $result;
     }
 
     protected function readFieldValue(array $field)
@@ -459,14 +635,17 @@ class IblockExchangeHelper extends IblockHelper implements ReaderHelperInterface
         return $iproperty;
     }
 
-    protected function readPropertyHtml(int $iblockId, array $prop)
+    protected function readPropertyHtml(int $iblockId, array $prop, array $fileLinks = [])
     {
         $isMultiple = $this->isPropertyMultiple($iblockId, $prop['name']);
         $res = [];
-        foreach ($prop['value'] as $val) {
+        foreach ($prop['value'] as $index => $val) {
             $res[] = [
                 'VALUE'       => [
-                    'TEXT' => $val['value'],
+                    'TEXT' => $this->importXmlTextFileLinks(
+                        $val['value'],
+                        $fileLinks[$index] ?? []
+                    ),
                     'TYPE' => $val['text-type'] ?? 'html',
                 ],
                 'DESCRIPTION' => $val['description'] ?? '',
@@ -474,6 +653,30 @@ class IblockExchangeHelper extends IblockHelper implements ReaderHelperInterface
         }
 
         return ($isMultiple) ? $res : $res[0];
+    }
+
+    protected function importXmlTextFileLinks(string $text, array $fileLinks): string
+    {
+        if (empty($fileLinks)) {
+            return $text;
+        }
+
+        $linkMap = [];
+        foreach ($fileLinks as $oldLink => $file) {
+            if (!is_array($file)) {
+                continue;
+            }
+
+            Module::prepareLongDatabaseConnection();
+            $fileId = \CFile::SaveFile($file, 'sprint_migration/iblock_element_text');
+            Module::reconnectDatabase();
+
+            if ($fileId) {
+                $linkMap[$oldLink] = (string)\CFile::GetPath($fileId);
+            }
+        }
+
+        return (new FileExchange())->replaceTextFileLinks($text, $linkMap);
     }
 
     protected function readPropertyString(int $iblockId, array $prop)
@@ -557,4 +760,5 @@ class IblockExchangeHelper extends IblockHelper implements ReaderHelperInterface
         }
         return ($isMultiple) ? $res : $res[0];
     }
+
 }

--- a/lib/helpers/traits/iblock/iblocksectiontrait.php
+++ b/lib/helpers/traits/iblock/iblocksectiontrait.php
@@ -4,6 +4,7 @@ namespace Sprint\Migration\Helpers\Traits\Iblock;
 
 use CIBlockSection;
 use Sprint\Migration\Exceptions\HelperException;
+use Sprint\Migration\Exchange\FileExchange;
 use Sprint\Migration\Locale;
 
 trait IblockSectionTrait
@@ -291,7 +292,7 @@ trait IblockSectionTrait
     /**
      * @throws HelperException
      */
-    public function saveSectionsFromTree(int $iblockId, array $tree, $parentId = false): void
+    public function saveSectionsFromTree(int $iblockId, array $tree, $parentId = false, string $exchangeDir = ''): void
     {
         foreach ($tree as $item) {
             if (empty($item['NAME'])) {
@@ -309,6 +310,8 @@ trait IblockSectionTrait
             }
 
             $item['IBLOCK_SECTION_ID'] = $parentId;
+            $item = $this->prepareSectionForSave($iblockId, $item, $exchangeDir);
+            $userFields = $this->extractSectionUserFields($item);
 
             $sectionId = $this->getSectionId(
                 $iblockId, [
@@ -323,8 +326,10 @@ trait IblockSectionTrait
                 $sectionId = $this->addSection($iblockId, $item);
             }
 
+            $this->saveSectionUserFields($iblockId, $sectionId, $userFields);
+
             if (!empty($childs)) {
-                $this->saveSectionsFromTree($iblockId, $childs, $sectionId);
+                $this->saveSectionsFromTree($iblockId, $childs, $sectionId, $exchangeDir);
             }
         }
     }
@@ -335,20 +340,27 @@ trait IblockSectionTrait
         return $this->buildSectionsTree($sections);
     }
 
-    public function exportSectionsTree(int $iblockId): array
+    public function exportSectionsTree(int $iblockId, string $exchangeDir = ''): array
     {
         $sections = $this->getSections($iblockId);
-        return $this->buildSectionsTree($sections, 0, true);
+        return $this->buildSectionsTree($sections, 0, true, $exchangeDir, $iblockId);
     }
 
-    protected function buildSectionsTree(array &$sections, int $parentId = 0, bool $export = false): array
+    protected function buildSectionsTree(
+        array &$sections,
+        int $parentId = 0,
+        bool $export = false,
+        string $exchangeDir = '',
+        int $iblockId = 0
+    ): array
     {
         $branch = [];
         foreach ($sections as $section) {
             if ((int)$section['IBLOCK_SECTION_ID'] == $parentId) {
-                $childs = $this->buildSectionsTree($sections, $section['ID'], $export);
+                $childs = $this->buildSectionsTree($sections, $section['ID'], $export, $exchangeDir, $iblockId);
 
                 if ($export) {
+                    $section = $this->prepareSectionForExport($iblockId, $section, $exchangeDir);
                     $this->unsetKeys($section, [
                         'ID',
                         'IBLOCK_SECTION_ID',
@@ -365,5 +377,369 @@ trait IblockSectionTrait
             }
         }
         return $branch;
+    }
+
+    protected function prepareSectionForExport(int $iblockId, array $section, string $exchangeDir = ''): array
+    {
+        if ($exchangeDir === '') {
+            return $section;
+        }
+
+        $fileExchange = new FileExchange();
+
+        foreach (['PICTURE', 'DETAIL_PICTURE'] as $fieldName) {
+            if (!empty($section[$fieldName]) && is_numeric($section[$fieldName])) {
+                $section[$fieldName] = $fileExchange->exportFileById(
+                    (int)$section[$fieldName],
+                    $exchangeDir,
+                    'iblock_section_files'
+                );
+            }
+        }
+
+        $section = $this->exportSectionTextFileLinks($section, 'DESCRIPTION', $exchangeDir);
+        $userFields = $this->getSectionUserFields($iblockId);
+
+        foreach ($section as $fieldName => $value) {
+            if (!str_starts_with((string)$fieldName, 'UF_') || empty($userFields[$fieldName])) {
+                continue;
+            }
+
+            $section[$fieldName] = $this->exportSectionUserFieldValue(
+                $userFields[$fieldName],
+                $value,
+                $exchangeDir
+            );
+
+            if ($this->isSectionUserFieldText($userFields[$fieldName])) {
+                $section = $this->exportSectionUserFieldTextLinks(
+                    $section,
+                    $userFields[$fieldName],
+                    (string)$fieldName,
+                    $exchangeDir
+                );
+            }
+        }
+
+        return $section;
+    }
+
+    protected function prepareSectionForSave(int $iblockId, array $section, string $exchangeDir = ''): array
+    {
+        $fileLinks = [];
+        if (isset($section['__FILE_LINKS']) && is_array($section['__FILE_LINKS'])) {
+            $fileLinks = $section['__FILE_LINKS'];
+        }
+        unset($section['__FILE_LINKS']);
+
+        if ($exchangeDir === '') {
+            return $section;
+        }
+
+        $fileExchange = new FileExchange();
+
+        foreach (['PICTURE', 'DETAIL_PICTURE'] as $fieldName) {
+            if (!empty($section[$fieldName]) && is_array($section[$fieldName])) {
+                $section[$fieldName] = $fileExchange->makeFileArrayByRef($section[$fieldName], $exchangeDir);
+            }
+        }
+
+        if (!empty($fileLinks['DESCRIPTION'])) {
+            $section['DESCRIPTION'] = $this->importSectionTextFileLinks(
+                (string)($section['DESCRIPTION'] ?? ''),
+                $fileLinks['DESCRIPTION'],
+                $exchangeDir
+            );
+        }
+
+        $userFields = $this->getSectionUserFields($iblockId);
+
+        foreach ($section as $fieldName => $value) {
+            if (!str_starts_with((string)$fieldName, 'UF_') || empty($userFields[$fieldName])) {
+                continue;
+            }
+
+            $section[$fieldName] = $this->importSectionUserFieldValue(
+                $userFields[$fieldName],
+                $value,
+                $exchangeDir
+            );
+
+            if (!empty($fileLinks[$fieldName])) {
+                $section[$fieldName] = $this->importSectionUserFieldTextLinks(
+                    $section[$fieldName],
+                    $fileLinks[$fieldName],
+                    $exchangeDir
+                );
+            }
+        }
+
+        return $section;
+    }
+
+    protected function exportSectionTextFileLinks(array $section, string $fieldName, string $exchangeDir): array
+    {
+        if (empty($section[$fieldName])) {
+            return $section;
+        }
+
+        $value = $section[$fieldName];
+        $text = is_array($value) ? (string)($value['TEXT'] ?? '') : (string)$value;
+        $links = (new FileExchange())->exportTextFileLinks($text, $exchangeDir, 'iblock_section_text');
+        if (!empty($links)) {
+            $section['__FILE_LINKS'][$fieldName][0] = $links;
+        }
+
+        return $section;
+    }
+
+    protected function exportSectionUserFieldTextLinks(
+        array $section,
+        array $field,
+        string $fieldName,
+        string $exchangeDir
+    ): array {
+        if (empty($section[$fieldName])) {
+            return $section;
+        }
+
+        $multiple = (($field['MULTIPLE'] ?? 'N') === 'Y');
+        $values = $multiple ? array_values((array)$section[$fieldName]) : [$section[$fieldName]];
+
+        foreach ($values as $index => $value) {
+            $text = is_array($value) ? (string)($value['TEXT'] ?? '') : (string)$value;
+            $links = (new FileExchange())->exportTextFileLinks($text, $exchangeDir, 'iblock_section_text');
+            if (!empty($links)) {
+                $section['__FILE_LINKS'][$fieldName][$index] = $links;
+            }
+        }
+
+        return $section;
+    }
+
+    protected function importSectionTextFileLinks(string $text, array $fileLinks, string $exchangeDir): string
+    {
+        $linkMap = [];
+        foreach ($fileLinks as $indexLinks) {
+            foreach ((array)$indexLinks as $oldLink => $fileRef) {
+                if (!is_array($fileRef)) {
+                    continue;
+                }
+
+                $newLink = (new FileExchange())->saveFileRefAndGetPath(
+                    $fileRef,
+                    $exchangeDir,
+                    'sprint_migration/iblock_section_text'
+                );
+                if ($newLink !== '') {
+                    $linkMap[$oldLink] = $newLink;
+                }
+            }
+        }
+
+        return (new FileExchange())->replaceTextFileLinks($text, $linkMap);
+    }
+
+    protected function exportSectionUserFieldValue(array $field, mixed $value, string $exchangeDir): mixed
+    {
+        if ($field['USER_TYPE_ID'] === 'file') {
+            return $this->exportSectionUserFieldFileValue($field, $value, $exchangeDir);
+        }
+
+        if ($field['USER_TYPE_ID'] === 'enumeration') {
+            return $this->exportSectionUserFieldEnumValue($field, $value);
+        }
+
+        return $value;
+    }
+
+    protected function importSectionUserFieldValue(array $field, mixed $value, string $exchangeDir): mixed
+    {
+        if ($field['USER_TYPE_ID'] === 'file') {
+            return $this->importSectionUserFieldFileValue($field, $value, $exchangeDir);
+        }
+
+        if ($field['USER_TYPE_ID'] === 'enumeration') {
+            return $this->importSectionUserFieldEnumValue($field, $value);
+        }
+
+        return $value;
+    }
+
+    protected function exportSectionUserFieldFileValue(array $field, mixed $value, string $exchangeDir): mixed
+    {
+        $multiple = (($field['MULTIPLE'] ?? 'N') === 'Y');
+        if (empty($value)) {
+            return $multiple ? [] : false;
+        }
+
+        $items = [];
+        foreach ($this->makeNonEmptyArray($value) as $fileId) {
+            $fileRef = (new FileExchange())->exportFileById((int)$fileId, $exchangeDir, 'iblock_section_files');
+            if ($fileRef) {
+                $items[] = $fileRef;
+            }
+        }
+
+        return $multiple ? $items : ($items[0] ?? false);
+    }
+
+    protected function importSectionUserFieldFileValue(array $field, mixed $value, string $exchangeDir): mixed
+    {
+        $multiple = (($field['MULTIPLE'] ?? 'N') === 'Y');
+        if (empty($value)) {
+            return $multiple ? [] : false;
+        }
+
+        $items = [];
+        foreach ($this->makeSectionUserFieldFileRefs($value, $multiple) as $fileRef) {
+            if (!is_array($fileRef)) {
+                continue;
+            }
+
+            $file = (new FileExchange())->makeFileArrayByRef($fileRef, $exchangeDir);
+            if ($file) {
+                $items[] = $file;
+            }
+        }
+
+        return $multiple ? $items : ($items[0] ?? false);
+    }
+
+    protected function makeSectionUserFieldFileRefs(mixed $value, bool $multiple): array
+    {
+        if (!$multiple && is_array($value) && isset($value['path'])) {
+            return [$value];
+        }
+
+        return $this->makeNonEmptyArray($value);
+    }
+
+    protected function exportSectionUserFieldEnumValue(array $field, mixed $value): mixed
+    {
+        $multiple = (($field['MULTIPLE'] ?? 'N') === 'Y');
+        if (empty($value)) {
+            return $multiple ? [] : '';
+        }
+
+        $map = $this->getSectionUserFieldEnumExportMap((int)$field['ID']);
+        $items = [];
+        foreach ($this->makeNonEmptyArray($value) as $enumId) {
+            if (isset($map[(int)$enumId])) {
+                $items[] = $map[(int)$enumId];
+            }
+        }
+
+        return $multiple ? $items : ($items[0] ?? '');
+    }
+
+    protected function importSectionUserFieldEnumValue(array $field, mixed $value): mixed
+    {
+        $multiple = (($field['MULTIPLE'] ?? 'N') === 'Y');
+        if (empty($value)) {
+            return $multiple ? [] : false;
+        }
+
+        $map = $this->getSectionUserFieldEnumImportMap((int)$field['ID']);
+        $items = [];
+        foreach ($this->makeNonEmptyArray($value) as $enumXmlId) {
+            if (isset($map[(string)$enumXmlId])) {
+                $items[] = $map[(string)$enumXmlId];
+            }
+        }
+
+        return $multiple ? $items : ($items[0] ?? false);
+    }
+
+    protected function importSectionUserFieldTextLinks(mixed $value, array $fileLinks, string $exchangeDir): mixed
+    {
+        $isFormattedSingle = is_array($value) && (array_key_exists('TEXT', $value) || array_key_exists('TYPE', $value));
+        $values = (is_array($value) && !$isFormattedSingle) ? array_values($value) : [$value];
+
+        foreach ($values as $index => $item) {
+            if (empty($fileLinks[$index])) {
+                continue;
+            }
+
+            $text = is_array($item) ? (string)($item['TEXT'] ?? '') : (string)$item;
+            $text = $this->importSectionTextFileLinks($text, [$fileLinks[$index]], $exchangeDir);
+
+            if (is_array($item)) {
+                $item['TEXT'] = $text;
+                $values[$index] = $item;
+            } else {
+                $values[$index] = $text;
+            }
+        }
+
+        return (is_array($value) && !$isFormattedSingle) ? $values : ($values[0] ?? $value);
+    }
+
+    protected function getSectionUserFields(int $iblockId): array
+    {
+        $result = [];
+        if (!class_exists('\CUserTypeEntity')) {
+            return $result;
+        }
+
+        $dbres = \CUserTypeEntity::GetList([], ['ENTITY_ID' => 'IBLOCK_' . $iblockId . '_SECTION']);
+        while ($field = $dbres->Fetch()) {
+            $result[$field['FIELD_NAME']] = $field;
+        }
+
+        return $result;
+    }
+
+    protected function getSectionUserFieldEnumExportMap(int $fieldId): array
+    {
+        $result = [];
+        $dbres = (new \CUserFieldEnum())->GetList([], ['USER_FIELD_ID' => $fieldId]);
+        while ($enum = $dbres->Fetch()) {
+            $result[(int)$enum['ID']] = (string)$enum['XML_ID'];
+        }
+
+        return $result;
+    }
+
+    protected function getSectionUserFieldEnumImportMap(int $fieldId): array
+    {
+        $result = [];
+        $dbres = (new \CUserFieldEnum())->GetList([], ['USER_FIELD_ID' => $fieldId]);
+        while ($enum = $dbres->Fetch()) {
+            $result[(string)$enum['XML_ID']] = (int)$enum['ID'];
+        }
+
+        return $result;
+    }
+
+    protected function isSectionUserFieldText(array $field): bool
+    {
+        return in_array($field['USER_TYPE_ID'], ['string', 'string_formatted', 'html']);
+    }
+
+    protected function extractSectionUserFields(array &$section): array
+    {
+        $userFields = [];
+        foreach ($section as $fieldName => $value) {
+            if (str_starts_with((string)$fieldName, 'UF_')) {
+                $userFields[$fieldName] = $value;
+                unset($section[$fieldName]);
+            }
+        }
+
+        return $userFields;
+    }
+
+    protected function saveSectionUserFields(int $iblockId, int $sectionId, array $userFields): void
+    {
+        if (empty($userFields) || empty($GLOBALS['USER_FIELD_MANAGER'])) {
+            return;
+        }
+
+        $GLOBALS['USER_FIELD_MANAGER']->Update(
+            'IBLOCK_' . $iblockId . '_SECTION',
+            $sectionId,
+            $userFields
+        );
     }
 }

--- a/lib/module.php
+++ b/lib/module.php
@@ -4,11 +4,13 @@ namespace Sprint\Migration;
 
 use COption;
 use Sprint\Migration\Exceptions\MigrationException;
+use Throwable;
 
 class Module
 {
     const ID = 'sprint.migration';
-    const EXCHANGE_VERSION = 2;
+    const EXCHANGE_VERSION_LEGACY = 2;
+    const EXCHANGE_VERSION = 3;
     private static string $version = '';
 
     public static function getDbOption($name, $default = '')
@@ -36,6 +38,40 @@ class Module
     public static function getDocRoot(): string
     {
         return rtrim($_SERVER['DOCUMENT_ROOT'], DIRECTORY_SEPARATOR);
+    }
+
+    public static function prepareLongDatabaseConnection(int $waitTimeout = 28800): void
+    {
+        if (!class_exists('\Bitrix\Main\Application')) {
+            return;
+        }
+
+        try {
+            $connection = \Bitrix\Main\Application::getConnection();
+            $waitTimeout = max(1, $waitTimeout);
+            $connection->queryExecute('SET SESSION wait_timeout=' . $waitTimeout);
+            $connection->queryExecute('SET SESSION interactive_timeout=' . $waitTimeout);
+        } catch (Throwable) {
+        }
+    }
+
+    public static function reconnectDatabase(int $waitTimeout = 28800): void
+    {
+        if (!class_exists('\Bitrix\Main\Application')) {
+            return;
+        }
+
+        try {
+            \Bitrix\Main\Application::getConnection()->disconnect();
+
+            global $DB;
+            if (is_object($DB) && method_exists($DB, 'DoConnect')) {
+                $DB->DoConnect();
+            }
+        } catch (Throwable) {
+        }
+
+        self::prepareLongDatabaseConnection($waitTimeout);
     }
 
     public static function getPhpInterfaceDir($absolute = true): string
@@ -150,6 +186,3 @@ class Module
         }
     }
 }
-
-
-

--- a/lib/versionmanager.php
+++ b/lib/versionmanager.php
@@ -82,15 +82,19 @@ class VersionManager
             $versionInstance->setVersionConfig($this->versionConfig);
             $versionInstance->setRestartParams($params);
 
+            Module::prepareLongDatabaseConnection();
+
             if ($action == VersionEnum::ACTION_UP) {
                 $this->checkResultAfterStart($versionInstance->up());
 
                 $meta['tag'] = $tag;
 
+                Module::reconnectDatabase();
                 $this->getVersionTable()->addRecord($meta);
             } else {
                 $this->checkResultAfterStart($versionInstance->down());
 
+                Module::reconnectDatabase();
                 $this->getVersionTable()->removeRecord($meta);
             }
         } catch (RestartException $e) {

--- a/templates/FormExport.php
+++ b/templates/FormExport.php
@@ -36,8 +36,9 @@ class <?php echo $version ?> extends <?php echo $extendClass ?>
     public function up()
     {
         $helper = $this->getHelperManager();
+        $exchangeDir = $this->getVersionConfig()->getVersionExchangeDir($this->getVersionName());
 <?php if (!empty($formExport)): ?>
-        $formId = $helper->Form()->saveForm(<?= var_export($form, 1)?>);
+        $formId = $helper->Form()->saveForm(<?= var_export($form, 1)?>, $exchangeDir);
 <?php else:?>
         $formId = $helper->Form()->getFormIdIfExists('<?= $form['SID']?>');
 <?php endif?>
@@ -45,13 +46,12 @@ class <?php echo $version ?> extends <?php echo $extendClass ?>
         $helper->Form()->saveStatuses($formId, <?= var_export($statuses, 1)?>);
 <?php endif;?>
 <?php if (!empty($fields) && $fieldsMode == 'all'): ?>
-        $helper->Form()->saveFields($formId, <?= var_export($fields, 1)?>);
+        $helper->Form()->saveFields($formId, <?= var_export($fields, 1)?>, $exchangeDir);
 <?php endif;?>
 <?php if (!empty($fields) && $fieldsMode == 'some'): ?>
     <?php foreach ($fields as $field) { ?>
-        $helper->Form()->saveField($formId, <?= var_export($field, 1)?>);
+        $helper->Form()->saveField($formId, <?= var_export($field, 1)?>, $exchangeDir);
     <?php } ?>
 <?php endif;?>
     }
 }
-

--- a/templates/IblockCategoryExport.php
+++ b/templates/IblockCategoryExport.php
@@ -33,6 +33,7 @@ class <?php echo $version ?> extends <?php echo $extendClass ?>
     public function up()
     {
         $helper = $this->getHelperManager();
+        $exchangeDir = $this->getVersionConfig()->getVersionExchangeDir($this->getVersionName());
 
         $iblockId = $helper->Iblock()->getIblockIdIfExists(
             '<?php echo $iblock['CODE'] ?>',
@@ -41,7 +42,9 @@ class <?php echo $version ?> extends <?php echo $extendClass ?>
 
         $helper->Iblock()->saveSectionsFromTree(
             $iblockId,
-            <?php echo var_export($sectionTree, 1) ?>
+            <?php echo var_export($sectionTree, 1) ?>,
+            false,
+            $exchangeDir
         );
     }
 }


### PR DESCRIPTION
  ## Что сделано

  Добавлена расширенная поддержка переноса файлов при миграции элементов инфоблоков и блоговых записей.
  Основной акцент: корректный перенос файлов из `/upload`, Bitrix cloud/S3-хранилища и ссылок на файлы внутри HTML-текста.

https://github.com/andreyryabin/sprint.migration/issues/172 - возможно затрагивает это

  ## Как работает

  ### Общий файловый контур

  Добавлен общий `FileExchange`, который умеет:
  - экспортировать файл по `b_file.ID`;
  - экспортировать файл по ссылке;
  - корректно работать с Bitrix cloud/S3 через стандартный `CFile::MakeFileArray()`;
  - сохранять файл обратно через `CFile::SaveFile()`;
  - не скачивать внешние ссылки с чужих сайтов;
  - считать локальными только относительные `/upload/...` и абсолютные ссылки на домены текущего Bitrix-сайта.

  Домены текущего сайта берутся из:
  - `HTTP_HOST`;
  - `SERVER_NAME`;
  - `main/server_name`;
  - всех `CSite::SERVER_NAME`;
  - всех `CSite::DOMAINS`.

  ## Что дополнено в миграции элементов инфоблока

  Новые миграции элементов инфоблока остаются в стандартном XML-контракте `iblock_elements.xml`.
  Версия обмена повышена до `EXCHANGE_VERSION = 3`.
  Старые XML-миграции версии `2` продолжают читаться как legacy.

  Для нового XML добавлен блок `file_links`, который переносит файлы из:
  - `DETAIL_TEXT`;
  - `PREVIEW_TEXT`;
  - HTML-свойств инфоблока `S:HTML`.

  Поддерживаются ссылки из:
  - `src`;
  - `href`;
  - `srcset`;
  - `data-srcset`;
  - `data-src`;
  - `data-lazy-src`;
  - `data-original`;
  - CSS `url(...)`;
  - `[IMG]...[/IMG]`.

  Для множественных `S:HTML` исправлено сопоставление индексов, чтобы файлы возвращались в правильное значение свойства.

  ## Что дополнено для секций/категорий инфоблока
 - IblockCategoryBuilder теперь экспортирует секции с exchange-директорией.
  - IblockCategoryExport передает exchange-директорию в saveSectionsFromTree().
  - IblockSectionTrait теперь переносит для секций:
      - PICTURE
      - DETAIL_PICTURE
      - ссылки на файлы в DESCRIPTION
      - UF_* типа file
      - текстовые UF_* со ссылками на локальные/S3 файлы
      - UF_* enum через XML_ID

  ## Что дополнено для HL-элементов
  - Добавлен перенос файлов из текстовых пользовательских полей HL-блоков.
  - Поддержаны поля типов `string`, `html`, `string_formatted`.
  - При экспорте значения таких полей сканируются на локальные `/upload` и Bitrix cloud/S3 ссылки.
  - Найденные файлы копируются в exchange-директорию и записываются в XML как `file_links`.
  - При импорте файлы сохраняются через `CFile::SaveFile()`, а старые ссылки в тексте заменяются на новые пути.
  - Существующий перенос `UF file` сохранен и продолжает работать через общий XML writer/reader.

## Что дополнено для блогов

  Блоговые записи переведены на общий `FileExchange`.
  Через общий механизм теперь обрабатываются:
  - `ATTACH_IMG`;
  - пользовательские UF-файлы;
  - изображения блоговых записей;
  - ссылки на файлы внутри текста записи.
  
BlogHelper дополнительно поправлен для одиночного UF file: single file-ref больше не разваливается как ассоциативный массив.
Старые локальные методы копирования файлов в `BlogHelper` удалены как дублирующие, легаси подход в блогах, полностью убрал.

## Что дополнено для форм
 - Добавлена поддержка переноса `IMAGE_ID` у веб-форм.
  - Добавлена поддержка переноса `IMAGE_ID` у полей формы.
  - При экспорте изображения сохраняются через общий `FileExchange` в exchange-директорию миграции.
  - При импорте file-ref преобразуется в `arIMAGE`, то есть в штатный формат, который ожидают `CForm::Set()` и `CFormField::Set()`.
  - Старые миграции с числовым `IMAGE_ID` остаются совместимыми: новый формат используется для новых экспортов.

## Медиабиблиотека

Уже работает автоматически с S3 после доработки под инфоблоки

  ## S3 / cloud storage

  Для файлов из Bitrix cloud/S3 используется штатная схема Bitrix:
  - `CFile::MakeFileArray($fileId)` для получения файла из хранилища;
  - `CFile::SaveFile()` для сохранения файла на целевой стороне.
  Это позволяет использовать стандартные обработчики модуля `clouds`.

  ## Защита от долгих S3-операций
  Добавлена защита от падений вида `MySQL server has gone away` при долгих S3-операциях:
  - перед миграцией поднимается session `wait_timeout` / `interactive_timeout`;
  - после долгой миграции перед записью статуса делается reconnect DB;
  - в restartable import/export reconnect выполняется между пакетами;
  - при импорте XML reconnect выполняется между записями;
  - вокруг файловых `CFile::SaveFile()` добавлена подготовка длинного DB-соединения и reconnect после операции.

  Если окружение не разрешает `SET SESSION`, ошибка не ломает миграцию: модуль просто продолжит работу с обычным reconnect.

  ## Ограничения
  - Внешние ссылки на чужие сайты не скачиваются и не заменяются.
  - CDN-домен будет считаться локальным только если он указан в настройках сайта/доменах Bitrix.
  - Старые XML v2 читаются, но не получают новый `file_links`, поэтому картинки из текста старых миграций по новой схеме не восстанавливаются.