### PR TITLE
Переделал обмен для записей блога на XML-формат

### DIFF
--- a/lib/builders/blogpostbuilder.php
+++ b/lib/builders/blogpostbuilder.php
@@ -5,6 +5,8 @@ namespace Sprint\Migration\Builders;
 use Sprint\Migration\Exceptions\HelperException;
 use Sprint\Migration\Exceptions\MigrationException;
 use Sprint\Migration\Exceptions\RebuildException;
+use Sprint\Migration\Exceptions\RestartException;
+use Sprint\Migration\Exchange\RestartableWriter;
 use Sprint\Migration\Locale;
 use Sprint\Migration\Module;
 use Sprint\Migration\VersionBuilder;
@@ -36,46 +38,51 @@ class BlogPostBuilder extends VersionBuilder
      * @throws HelperException
      * @throws MigrationException
      * @throws RebuildException
+     * @throws RestartException
      */
     protected function execute()
     {
         $helper = $this->getHelperManager();
+        $exhelper = $this->getHelperManager()->BlogExchange();
+
         $blogId = (int)$this->addFieldAndReturn('blog_id', [
             'title' => Locale::getMessage('BUILDER_BlogPostExport_blog_id'),
             'width' => 350,
             'items' => $this->getBlogsSelect(),
         ]);
 
-        $blog = $helper->Blog()->exportBlogById($blogId);
-        $blogRef = [
-            'GROUP' => $blog['GROUP'],
-            'URL'   => $blog['URL'],
-        ];
+        $helper->Blog()->exportBlogById($blogId);
 
-        $version = $this->getVersionName();
-        $exchangeDir = $this->getVersionConfig()->getVersionExchangeDir($version);
-
-        $postIds = $this->getPostIds($blogId);
-        $posts = $helper->Blog()->exportPosts($postIds, $exchangeDir);
-
-        if (empty($posts)) {
+        $filter = $this->getPostFilter();
+        if (!$exhelper->getWriterRecordsCount($blogId, $filter)) {
             $this->rebuildField('post_filter_mode');
         }
 
-        $this->createVersionFile(
-            Module::getModuleTemplateFile('BlogPostExport'),
-            [
-                'version' => $version,
-                'blog'    => $blogRef,
-                'posts'   => $posts,
-            ]
-        );
+        (new RestartableWriter($this, $this->getVersionExchangeDir()))
+            ->setExchangeResource('blog_posts.xml')
+            ->execute(
+                attributesFn: fn() => $exhelper->getWriterAttributes($blogId),
+                totalCountFn: fn() => $exhelper->getWriterRecordsCount($blogId, $filter),
+                recordsFn: fn($offset, $limit) => $exhelper->getWriterRecordsTag(
+                    $offset,
+                    $limit,
+                    $blogId,
+                    $filter
+                ),
+                progressFn: fn($value, $totalCount) => $this->outProgress(
+                    'Progress: ',
+                    $value,
+                    $totalCount
+                )
+            );
+
+        $this->createVersionFile(Module::getModuleTemplateFile('BlogPostExport'));
     }
 
     /**
      * @throws RebuildException
      */
-    protected function getPostIds(int $blogId): array
+    protected function getPostFilter(): array
     {
         $mode = $this->addFieldAndReturn('post_filter_mode', [
             'title' => Locale::getMessage('BUILDER_BlogPostExport_filter'),
@@ -103,7 +110,8 @@ class BlogPostBuilder extends VersionBuilder
                 'height' => 40,
             ]);
 
-            return array_map('intval', $this->explodeString($ids));
+            $ids = array_values(array_filter(array_map('intval', $this->explodeString($ids))));
+            return empty($ids) ? ['ID' => 0] : ['@ID' => $ids];
         }
 
         $filter = [];
@@ -116,13 +124,13 @@ class BlogPostBuilder extends VersionBuilder
 
             $codes = $this->explodeString($codes);
             if (empty($codes)) {
-                return [];
+                return ['ID' => 0];
             }
 
             $filter['@CODE'] = $codes;
         }
 
-        return array_column($this->getHelperManager()->Blog()->getPosts($blogId, $filter), 'ID');
+        return $filter;
     }
 
     protected function getBlogsSelect(): array

--- a/lib/exchange/exchangemanager.php
+++ b/lib/exchange/exchangemanager.php
@@ -43,4 +43,13 @@ class ExchangeManager
             $this->directory
         ))->setExchangeResource('medialib_elements.xml');
     }
+
+    public function BlogPostsImport(): RestartableReader
+    {
+        return (new RestartableReader(
+            $this->restartable,
+            $this->getHelperManager()->BlogExchange(),
+            $this->directory
+        ))->setExchangeResource('blog_posts.xml');
+    }
 }

--- a/lib/helpermanager.php
+++ b/lib/helpermanager.php
@@ -4,6 +4,7 @@ namespace Sprint\Migration;
 
 use Sprint\Migration\Exceptions\HelperException;
 use Sprint\Migration\Helpers\AgentHelper;
+use Sprint\Migration\Helpers\BlogExchangeHelper;
 use Sprint\Migration\Helpers\BlogHelper;
 use Sprint\Migration\Helpers\CultureHelper;
 use Sprint\Migration\helpers\DeliveryServiceHelper;
@@ -36,6 +37,7 @@ use Sprint\Migration\Helpers\VoteHelper;
  * @method HlblockHelper            Hlblock()
  * @method AgentHelper              Agent()
  * @method BlogHelper               Blog()
+ * @method BlogExchangeHelper       BlogExchange()
  * @method EventHelper              Event()
  * @method LangHelper               Lang()
  * @method SiteHelper               Site()

--- a/lib/helpers/blogexchangehelper.php
+++ b/lib/helpers/blogexchangehelper.php
@@ -1,0 +1,270 @@
+<?php
+
+namespace Sprint\Migration\Helpers;
+
+use CBlogPost;
+use CUserFieldEnum;
+use Sprint\Migration\Exceptions\HelperException;
+use Sprint\Migration\Exchange\WriterTag;
+use Sprint\Migration\Interfaces\ReaderHelperInterface;
+use Sprint\Migration\Interfaces\WriterHelperInterface;
+
+class BlogExchangeHelper extends BlogHelper implements ReaderHelperInterface, WriterHelperInterface
+{
+    /**
+     * @throws HelperException
+     */
+    public function getWriterAttributes(...$vars): array
+    {
+        [$blogId] = $vars;
+        $blog = $this->getBlogById((int)$blogId);
+
+        return [
+            'blogUrl' => $blog['URL'],
+        ];
+    }
+
+    public function getWriterRecordsCount(...$vars): int
+    {
+        [$blogId, $filter] = $vars;
+
+        return count($this->getPosts((int)$blogId, (array)$filter));
+    }
+
+    /**
+     * @throws HelperException
+     */
+    public function getWriterRecordsTag(int $offset, int $limit, ...$vars): WriterTag
+    {
+        [$blogId, $filter] = $vars;
+
+        $tag = new WriterTag('tmp');
+        foreach ($this->getPostIds((int)$blogId, (array)$filter, $offset, $limit) as $postId) {
+            $tag->addChild($this->createWriterRecordTag($this->exportPostForXml((int)$postId)));
+        }
+
+        return $tag;
+    }
+
+    /**
+     * @throws HelperException
+     */
+    public function convertReaderRecords(array $attributes, array $records): array
+    {
+        $this->checkRequiredKeys($attributes, ['blogUrl']);
+
+        $blogId = $this->getBlogIdByUrl($attributes['blogUrl']);
+        if (!$blogId) {
+            throw new HelperException("Blog \"{$attributes['blogUrl']}\" not found");
+        }
+
+        return array_map(
+            fn($record) => [
+                'blog_id' => $blogId,
+                'fields'  => $this->convertReaderRecord($record),
+            ],
+            $records
+        );
+    }
+
+    protected function getPostIds(int $blogId, array $filter, int $offset, int $limit): array
+    {
+        $filter['BLOG_ID'] = $blogId;
+
+        $dbres = CBlogPost::GetList(
+            [
+                'DATE_PUBLISH' => 'DESC',
+                'ID'           => 'DESC',
+            ],
+            $filter,
+            false,
+            false,
+            ['ID']
+        );
+
+        $ids = [];
+        $index = 0;
+        while ($post = $dbres->Fetch()) {
+            if ($index++ < $offset) {
+                continue;
+            }
+            if (count($ids) >= $limit) {
+                break;
+            }
+
+            $ids[] = (int)$post['ID'];
+        }
+
+        return $ids;
+    }
+
+    /**
+     * @throws HelperException
+     */
+    protected function exportPostForXml(int $postId): array
+    {
+        $post = $this->getPostById($postId);
+        if (empty($post['CODE'])) {
+            throw new HelperException("Blog post \"$postId\" has empty CODE");
+        }
+
+        $post['AUTHOR_LOGIN'] = $this->userHelper->getUserLoginById((int)$post['AUTHOR_ID']);
+        $post['CATEGORIES'] = $this->exportPostCategories((int)$post['BLOG_ID'], (int)$post['ID']);
+        $post['PERMS_POST'] = $this->exportPostPerms((int)$post['BLOG_ID'], (int)$post['ID'], BLOG_PERMS_POST);
+        $post['PERMS_COMMENT'] = $this->exportPostPerms((int)$post['BLOG_ID'], (int)$post['ID'], BLOG_PERMS_COMMENT);
+
+        return array_merge(
+            $this->prepareExportPost($post),
+            $this->exportPostUserFieldsForXml((int)$post['ID'])
+        );
+    }
+
+    protected function createWriterRecordTag(array $post): WriterTag
+    {
+        $item = new WriterTag('item');
+
+        foreach ($post as $name => $value) {
+            if (str_starts_with((string)$name, 'UF_')) {
+                $field = $this->createWriterUserFieldTag((string)$name, $value);
+            } else {
+                $field = new WriterTag('field', ['name' => $name]);
+            }
+
+            if ($name === 'ATTACH_IMG') {
+                $field->addFile((int)$value, false);
+            } elseif (!str_starts_with((string)$name, 'UF_')) {
+                $field->addValue($value, false);
+            }
+
+            $item->addChild($field);
+        }
+
+        return $item;
+    }
+
+    protected function convertReaderRecord(array $record): array
+    {
+        $fields = [];
+
+        foreach ($record['fields'] as $field) {
+            if (empty($field['name'])) {
+                continue;
+            }
+
+            if (str_starts_with((string)$field['name'], 'UF_')) {
+                $fields[$field['name']] = $this->readUserFieldValue($field);
+            } else {
+                $fields[$field['name']] = $this->readFieldValue($field);
+            }
+        }
+
+        return $fields;
+    }
+
+    protected function readFieldValue(array $field): mixed
+    {
+        return $field['value'][0]['value'] ?? null;
+    }
+
+    protected function exportPostUserFieldsForXml(int $postId): array
+    {
+        global $USER_FIELD_MANAGER;
+
+        if (empty($USER_FIELD_MANAGER)) {
+            return [];
+        }
+
+        $result = [];
+        $fields = $USER_FIELD_MANAGER->GetUserFields('BLOG_POST', $postId, LANGUAGE_ID);
+        foreach ($fields as $fieldName => $field) {
+            if (!str_starts_with($fieldName, 'UF_')) {
+                continue;
+            }
+
+            $value = $this->exportPostUserFieldValueForXml($field);
+            if ($value !== null && $value !== [] && $value !== '' && $value !== false) {
+                $result[$fieldName] = $value;
+            }
+        }
+
+        return $result;
+    }
+
+    protected function exportPostUserFieldValueForXml(array $field): mixed
+    {
+        $value = $field['VALUE'] ?? null;
+        $multiple = (($field['MULTIPLE'] ?? 'N') === 'Y');
+
+        if ($field['USER_TYPE_ID'] === 'enumeration') {
+            return $this->exportUserFieldEnumValueForXml($field, $value, $multiple);
+        }
+
+        if ($field['USER_TYPE_ID'] === 'file') {
+            if (empty($value)) {
+                return $multiple ? [] : false;
+            }
+
+            $values = array_values(array_filter($this->makeNonEmptyArray($value)));
+            return $multiple ? $values : ((int)($values[0] ?? 0) ?: false);
+        }
+
+        return $value;
+    }
+
+    protected function exportUserFieldEnumValueForXml(array $field, mixed $value, bool $multiple): mixed
+    {
+        if (empty($value)) {
+            return $multiple ? [] : '';
+        }
+
+        $enumMap = $this->getUserFieldEnumExportMapForXml((int)$field['ID']);
+        $values = [];
+
+        foreach ($this->makeNonEmptyArray($value) as $enumId) {
+            if (isset($enumMap[(int)$enumId])) {
+                $values[] = $enumMap[(int)$enumId];
+            }
+        }
+
+        return $multiple ? $values : ($values[0] ?? '');
+    }
+
+    protected function getUserFieldEnumExportMapForXml(int $fieldId): array
+    {
+        $result = [];
+        $dbres = (new CUserFieldEnum())->GetList([], ['USER_FIELD_ID' => $fieldId]);
+        while ($enum = $dbres->Fetch()) {
+            $result[(int)$enum['ID']] = !empty($enum['XML_ID']) ? $enum['XML_ID'] : $enum['VALUE'];
+        }
+
+        return $result;
+    }
+
+    protected function createWriterUserFieldTag(string $fieldName, mixed $value): WriterTag
+    {
+        $tag = new WriterTag('field', ['name' => $fieldName]);
+        $field = $this->getPostUserField($fieldName);
+        $multiple = (($field['MULTIPLE'] ?? 'N') === 'Y');
+
+        if (($field['USER_TYPE_ID'] ?? '') === 'file') {
+            $tag->addFile($value, $multiple);
+        } else {
+            $tag->addValue($value, $multiple);
+        }
+
+        return $tag;
+    }
+
+    protected function readUserFieldValue(array $field): mixed
+    {
+        $fieldInfo = $this->getPostUserField((string)$field['name']);
+        $multiple = (($fieldInfo['MULTIPLE'] ?? 'N') === 'Y');
+
+        $values = [];
+        foreach ($field['value'] as $value) {
+            $values[] = $value['value'];
+        }
+
+        return $multiple ? $values : ($values[0] ?? false);
+    }
+}

--- a/lib/helpers/blogexchangehelper.php
+++ b/lib/helpers/blogexchangehelper.php
@@ -112,7 +112,6 @@ class BlogExchangeHelper extends BlogHelper implements ReaderHelperInterface, Wr
         $post['CATEGORIES'] = $this->exportPostCategories((int)$post['BLOG_ID'], (int)$post['ID']);
         $post['PERMS_POST'] = $this->exportPostPerms((int)$post['BLOG_ID'], (int)$post['ID'], BLOG_PERMS_POST);
         $post['PERMS_COMMENT'] = $this->exportPostPerms((int)$post['BLOG_ID'], (int)$post['ID'], BLOG_PERMS_COMMENT);
-
         return array_merge(
             $this->prepareExportPost($post),
             $this->exportPostUserFieldsForXml((int)$post['ID'])
@@ -168,19 +167,9 @@ class BlogExchangeHelper extends BlogHelper implements ReaderHelperInterface, Wr
 
     protected function exportPostUserFieldsForXml(int $postId): array
     {
-        global $USER_FIELD_MANAGER;
-
-        if (empty($USER_FIELD_MANAGER)) {
-            return [];
-        }
-
         $result = [];
-        $fields = $USER_FIELD_MANAGER->GetUserFields('BLOG_POST', $postId, LANGUAGE_ID);
+        $fields = $this->getPostUserFieldsWithValues($postId);
         foreach ($fields as $fieldName => $field) {
-            if (!str_starts_with($fieldName, 'UF_')) {
-                continue;
-            }
-
             $value = $this->exportPostUserFieldValueForXml($field);
             if ($value !== null && $value !== [] && $value !== '' && $value !== false) {
                 $result[$fieldName] = $value;

--- a/lib/helpers/bloghelper.php
+++ b/lib/helpers/bloghelper.php
@@ -710,19 +710,9 @@ class BlogHelper extends Helper
 
     protected function exportPostUserFields(int $postId): array
     {
-        global $USER_FIELD_MANAGER;
-
-        if (empty($USER_FIELD_MANAGER)) {
-            return [];
-        }
-
         $result = [];
-        $fields = $USER_FIELD_MANAGER->GetUserFields('BLOG_POST', $postId, LANGUAGE_ID);
+        $fields = $this->getPostUserFieldsWithValues($postId);
         foreach ($fields as $fieldName => $field) {
-            if (!str_starts_with($fieldName, 'UF_')) {
-                continue;
-            }
-
             $value = $this->exportPostUserFieldValue($field);
             if ($value !== null && $value !== [] && $value !== '') {
                 $result[$fieldName] = $value;
@@ -730,6 +720,37 @@ class BlogHelper extends Helper
         }
 
         return $result;
+    }
+
+    /**
+     * @throws HelperException
+     */
+    protected function getPostUserFieldsWithValues(int $postId): array
+    {
+        $post = CBlogPost::GetList(
+            ['ID' => 'ASC'],
+            ['ID' => $postId],
+            false,
+            false,
+            ['ID', 'UF_*']
+        )->Fetch();
+
+        if (empty($post)) {
+            return [];
+        }
+
+        $fields = [];
+        foreach ((new UserTypeEntityHelper())->getUserTypeEntities('BLOG_POST') as $field) {
+            $fieldName = (string)($field['FIELD_NAME'] ?? '');
+            if (!str_starts_with($fieldName, 'UF_') || !array_key_exists($fieldName, $post)) {
+                continue;
+            }
+
+            $field['VALUE'] = $post[$fieldName];
+            $fields[$fieldName] = $field;
+        }
+
+        return $fields;
     }
 
     protected function exportPostUserFieldValue(array $field): mixed

--- a/lib/helpers/bloghelper.php
+++ b/lib/helpers/bloghelper.php
@@ -5,22 +5,19 @@ namespace Sprint\Migration\Helpers;
 use CBlog;
 use CBlogCategory;
 use CBlogGroup;
-use CBlogImage;
 use CBlogPost;
 use CBlogPostCategory;
 use CBlogUserGroup;
-use CFile;
 use CUserFieldEnum;
 use CUserTypeEntity;
 use Sprint\Migration\Exceptions\HelperException;
 use Sprint\Migration\Helper;
 use Sprint\Migration\Locale;
-use Sprint\Migration\Module;
 
 class BlogHelper extends Helper
 {
 
-    private UserHelper $userHelper;
+    protected UserHelper $userHelper;
 
     public function __construct()
     {
@@ -159,7 +156,7 @@ class BlogHelper extends Helper
     /**
      * @throws HelperException
      */
-    public function exportPostById(int $postId, string $exchangeDir = ''): array
+    protected function exportPostById(int $postId): array
     {
         $post = $this->getPostById($postId);
 
@@ -172,21 +169,10 @@ class BlogHelper extends Helper
         $post['CATEGORIES'] = $this->exportPostCategories((int)$post['BLOG_ID'], (int)$post['ID']);
         $post['PERMS_POST'] = $this->exportPostPerms((int)$post['BLOG_ID'], (int)$post['ID'], BLOG_PERMS_POST);
         $post['PERMS_COMMENT'] = $this->exportPostPerms((int)$post['BLOG_ID'], (int)$post['ID'], BLOG_PERMS_COMMENT);
-        $post['ATTACH_IMG'] = $this->exportFileRef((int)$post['ATTACH_IMG'], $exchangeDir, 'blog_post_files');
-        $post['UF_VALUES'] = $this->exportPostUserFields((int)$post['ID'], $exchangeDir);
-        $post['TEXT_IMAGES'] = $this->exportPostTextImages($post, $exchangeDir);
 
-        return $this->prepareExportPost($post);
-    }
-
-    /**
-     * @throws HelperException
-     */
-    public function exportPosts(array $postIds, string $exchangeDir = ''): array
-    {
-        return array_map(
-            fn($postId) => $this->exportPostById((int)$postId, $exchangeDir),
-            $this->makeNonEmptyArray($postIds)
+        return array_merge(
+            $this->prepareExportPost($post),
+            $this->exportPostUserFields((int)$post['ID'])
         );
     }
 
@@ -241,7 +227,7 @@ class BlogHelper extends Helper
     /**
      * @throws HelperException
      */
-    public function savePost(int $blogId, array $fields, string $exchangeDir = ''): int
+    public function savePost(int $blogId, array $fields): int
     {
         $this->checkRequiredKeys($fields, ['TITLE', 'DETAIL_TEXT', 'DATE_CREATE', 'DATE_PUBLISH', 'AUTHOR_LOGIN', 'CODE']);
 
@@ -249,22 +235,20 @@ class BlogHelper extends Helper
             throw new HelperException("Blog \"$blogId\" not found");
         }
 
-        $fieldsForSave = $this->preparePostFieldsForSave($blogId, $fields, $exchangeDir);
+        $fieldsForSave = $this->preparePostFieldsForSave($blogId, $fields);
         $postId = $this->getPostIdByCode($blogId, $fieldsForSave['CODE']);
 
         if (!$postId) {
             $postId = $this->addPost($fieldsForSave);
         } else {
-            $exists = $this->exportPostById($postId, $exchangeDir);
+            $exists = $this->exportPostById($postId);
             $export = $this->prepareExportPost(array_merge($fieldsForSave, [
                 'AUTHOR_LOGIN'  => $fields['AUTHOR_LOGIN'],
                 'CATEGORIES'    => $fields['CATEGORIES'] ?? [],
                 'PERMS_POST'    => $fields['PERMS_POST'] ?? [],
                 'PERMS_COMMENT' => $fields['PERMS_COMMENT'] ?? [],
                 'ATTACH_IMG'    => $fields['ATTACH_IMG'] ?? false,
-                'UF_VALUES'     => $fields['UF_VALUES'] ?? [],
-                'TEXT_IMAGES'   => $fields['TEXT_IMAGES'] ?? [],
-            ]));
+            ])) + $this->extractPostUserFields($fields);
 
             if ($this->checkDiff($exists, $export)) {
                 $postId = $this->updatePost($postId, $fieldsForSave);
@@ -272,8 +256,6 @@ class BlogHelper extends Helper
         }
 
         $this->savePostCategories($blogId, $postId, $fields['CATEGORIES'] ?? []);
-        $this->savePostTextImages($blogId, $postId, $fieldsForSave, $fields['TEXT_IMAGES'] ?? [], $exchangeDir);
-
         return $postId;
     }
 
@@ -525,7 +507,7 @@ class BlogHelper extends Helper
     /**
      * @throws HelperException
      */
-    protected function preparePostFieldsForSave(int $blogId, array $fields, string $exchangeDir = ''): array
+    protected function preparePostFieldsForSave(int $blogId, array $fields): array
     {
         $hasAttachImg = array_key_exists('ATTACH_IMG', $fields);
         $fields = array_merge($this->getDefaultPost(), $fields);
@@ -535,19 +517,15 @@ class BlogHelper extends Helper
         $fields['CATEGORY_ID'] = implode(',', $this->getCategoryIdsByNames($blogId, $fields['CATEGORIES'] ?? []));
         $fields['PERMS_POST'] = $this->revertPostPerms($blogId, $fields['PERMS_POST'] ?? []);
         $fields['PERMS_COMMENT'] = $this->revertPostPerms($blogId, $fields['PERMS_COMMENT'] ?? []);
-        $userFields = $this->revertPostUserFields($fields['UF_VALUES'] ?? [], $exchangeDir);
+        $userFields = $this->revertPostUserFields($this->extractPostUserFields($fields));
 
         if (!$hasAttachImg) {
             unset($fields['ATTACH_IMG']);
-        } elseif (!empty($fields['ATTACH_IMG']) && is_array($fields['ATTACH_IMG'])) {
-            $fields['ATTACH_IMG'] = $this->makeFileArrayByRef($fields['ATTACH_IMG'], $exchangeDir);
         }
 
         $this->unsetKeys($fields, [
             'AUTHOR_LOGIN',
             'CATEGORIES',
-            'UF_VALUES',
-            'TEXT_IMAGES',
         ]);
 
         $fields = array_intersect_key(
@@ -560,6 +538,18 @@ class BlogHelper extends Helper
         }
 
         return $fields;
+    }
+
+    protected function extractPostUserFields(array $fields): array
+    {
+        $result = [];
+        foreach ($fields as $name => $value) {
+            if (str_starts_with((string)$name, 'UF_')) {
+                $result[$name] = $value;
+            }
+        }
+
+        return $result;
     }
 
     protected function prepareExportBlog(array $fields): array
@@ -718,7 +708,7 @@ class BlogHelper extends Helper
         ]);
     }
 
-    protected function exportPostUserFields(int $postId, string $exchangeDir = ''): array
+    protected function exportPostUserFields(int $postId): array
     {
         global $USER_FIELD_MANAGER;
 
@@ -733,7 +723,7 @@ class BlogHelper extends Helper
                 continue;
             }
 
-            $value = $this->exportPostUserFieldValue($field, $exchangeDir);
+            $value = $this->exportPostUserFieldValue($field);
             if ($value !== null && $value !== [] && $value !== '') {
                 $result[$fieldName] = $value;
             }
@@ -742,7 +732,7 @@ class BlogHelper extends Helper
         return $result;
     }
 
-    protected function exportPostUserFieldValue(array $field, string $exchangeDir = ''): mixed
+    protected function exportPostUserFieldValue(array $field): mixed
     {
         $value = $field['VALUE'] ?? null;
         $multiple = (($field['MULTIPLE'] ?? 'N') === 'Y');
@@ -757,12 +747,7 @@ class BlogHelper extends Helper
             }
 
             $values = array_filter($this->makeNonEmptyArray($value));
-            $items = array_map(
-                fn($fileId) => $this->exportFileRef((int)$fileId, $exchangeDir, 'blog_post_files'),
-                $values
-            );
-            $items = array_values(array_filter($items));
-            return $multiple ? $items : ($items[0] ?? false);
+            return $multiple ? $values : ((int)($values[0] ?? 0) ?: false);
         }
 
         return $value;
@@ -787,7 +772,7 @@ class BlogHelper extends Helper
         return $multiple ? $values : ($values[0] ?? '');
     }
 
-    protected function revertPostUserFields(array $fields, string $exchangeDir = ''): array
+    protected function revertPostUserFields(array $fields): array
     {
         $result = [];
         foreach ($fields as $fieldName => $value) {
@@ -799,7 +784,7 @@ class BlogHelper extends Helper
             if ($field['USER_TYPE_ID'] === 'enumeration') {
                 $value = $this->revertUserFieldEnumValue($field, $value);
             } elseif ($field['USER_TYPE_ID'] === 'file') {
-                $value = $this->revertUserFieldFileValue($field, $value, $exchangeDir);
+                $value = $this->revertUserFieldFileValue($field, $value);
             }
 
             $result[$fieldName] = $value;
@@ -828,25 +813,14 @@ class BlogHelper extends Helper
         return $multiple ? $values : ($values[0] ?? false);
     }
 
-    protected function revertUserFieldFileValue(array $field, mixed $value, string $exchangeDir = ''): mixed
+    protected function revertUserFieldFileValue(array $field, mixed $value): mixed
     {
         $multiple = (($field['MULTIPLE'] ?? 'N') === 'Y');
         if (empty($value)) {
             return $multiple ? [] : false;
         }
 
-        $values = [];
-
-        foreach ($this->makeNonEmptyArray($value) as $fileRef) {
-            if (is_array($fileRef)) {
-                $file = $this->makeFileArrayByRef($fileRef, $exchangeDir);
-                if ($file) {
-                    $values[] = $file;
-                }
-            }
-        }
-
-        return $multiple ? $values : ($values[0] ?? false);
+        return $multiple ? $this->makeNonEmptyArray($value) : $value;
     }
 
     protected function getPostUserField(string $fieldName): array
@@ -885,351 +859,6 @@ class BlogHelper extends Helper
         }
 
         return $result;
-    }
-
-    protected function exportFileRef(int $fileId, string $exchangeDir = '', string $subdir = 'files'): array|false
-    {
-        if (!$fileId || $exchangeDir === '') {
-            return false;
-        }
-
-        $file = CFile::GetFileArray($fileId);
-        if (empty($file['SRC'])) {
-            return false;
-        }
-
-        $source = Module::getDocRoot() . $file['SRC'];
-        if (!is_file($source)) {
-            return false;
-        }
-
-        $relativePath = trim($subdir . '/' . $file['SUBDIR'] . '/' . $file['FILE_NAME'], '/');
-        $target = rtrim($exchangeDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $relativePath;
-        Module::createDir(dirname($target));
-        copy($source, $target);
-
-        return [
-            'path'        => $relativePath,
-            'name'        => $file['ORIGINAL_NAME'] ?? $file['FILE_NAME'],
-            'description' => $file['DESCRIPTION'] ?? '',
-        ];
-    }
-
-    protected function makeFileArrayByRef(array $fileRef, string $exchangeDir = ''): array|false
-    {
-        if (empty($fileRef['path']) || $exchangeDir === '') {
-            return false;
-        }
-
-        $path = rtrim($exchangeDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . ltrim($fileRef['path'], DIRECTORY_SEPARATOR);
-        $file = CFile::MakeFileArray($path);
-        if (empty($file)) {
-            return false;
-        }
-
-        if (!empty($fileRef['name'])) {
-            $file['name'] = $fileRef['name'];
-        }
-        if (!empty($fileRef['description'])) {
-            $file['description'] = $fileRef['description'];
-        }
-
-        return $file;
-    }
-
-    protected function exportPostTextImages(array $post, string $exchangeDir = ''): array
-    {
-        $texts = [
-            $post['DETAIL_TEXT'] ?? '',
-            $post['PREVIEW_TEXT'] ?? '',
-        ];
-
-        return array_filter([
-            'BLOG_IMAGES' => $this->exportPostBlogImages($post, $texts, $exchangeDir),
-            'FILE_LINKS'  => $this->exportPostTextFileLinks($texts, $exchangeDir),
-        ]);
-    }
-
-    protected function exportPostBlogImages(array $post, array $texts, string $exchangeDir = ''): array
-    {
-        $imageIds = [];
-        foreach ($texts as $text) {
-            if (preg_match_all('/\[IMG\s+ID=(\d+)[^\]]*\]/i', (string)$text, $matches)) {
-                foreach ($matches[1] as $imageId) {
-                    $imageIds[(int)$imageId] = (int)$imageId;
-                }
-            }
-        }
-
-        $result = [];
-        foreach ($imageIds as $imageId) {
-            $image = CBlogImage::GetByID($imageId);
-            if (empty($image['FILE_ID'])) {
-                continue;
-            }
-
-            if ((int)$image['POST_ID'] !== (int)$post['ID'] || (int)$image['BLOG_ID'] !== (int)$post['BLOG_ID']) {
-                continue;
-            }
-
-            $file = $this->exportFileRef((int)$image['FILE_ID'], $exchangeDir, 'blog_post_text_images');
-            if ($file) {
-                $result[$imageId] = [
-                    'FILE'       => $file,
-                    'TITLE'      => $image['TITLE'] ?? '',
-                    'USER_LOGIN' => $this->userHelper->getUserLoginById((int)($image['USER_ID'] ?? $post['AUTHOR_ID'])),
-                    'IMAGE_SIZE' => $image['IMAGE_SIZE'] ?? '',
-                ];
-            }
-        }
-
-        return $result;
-    }
-
-    protected function exportPostTextFileLinks(array $texts, string $exchangeDir = ''): array
-    {
-        $links = [];
-        foreach ($texts as $text) {
-            foreach ($this->extractLocalUploadLinks((string)$text) as $link) {
-                $file = $this->exportLocalFileRef($link, $exchangeDir, 'blog_post_text_links');
-                if ($file) {
-                    $links[$link] = $file;
-                }
-            }
-        }
-
-        return $links;
-    }
-
-    protected function extractLocalUploadLinks(string $text): array
-    {
-        $links = [];
-
-        if (preg_match_all('/<img\b[^>]*\bsrc\s*=\s*([\'"])(.*?)\1/iu', $text, $matches)) {
-            foreach ($matches[2] as $link) {
-                $links[] = html_entity_decode($link, ENT_QUOTES | ENT_HTML5);
-            }
-        }
-
-        if (preg_match_all('/\[IMG\]([^\[]+)\[\/IMG\]/iu', $text, $matches)) {
-            foreach ($matches[1] as $link) {
-                $links[] = trim($link);
-            }
-        }
-
-        return array_values(array_unique(array_filter(
-            $links,
-            fn($link) => $this->isLocalUploadLink((string)$link)
-        )));
-    }
-
-    protected function isLocalUploadLink(string $link): bool
-    {
-        $path = parse_url($link, PHP_URL_PATH);
-        return is_string($path) && str_starts_with($path, '/upload/');
-    }
-
-    protected function exportLocalFileRef(string $link, string $exchangeDir = '', string $subdir = 'files'): array|false
-    {
-        if ($exchangeDir === '') {
-            return false;
-        }
-
-        $path = parse_url($link, PHP_URL_PATH);
-        if (!is_string($path) || !str_starts_with($path, '/upload/')) {
-            return false;
-        }
-
-        $source = Module::getDocRoot() . rawurldecode($path);
-        if (!is_file($source)) {
-            return false;
-        }
-
-        $fileName = basename($source);
-        $relativePath = trim($subdir . '/' . md5($path) . '_' . $fileName, '/');
-        $target = rtrim($exchangeDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $relativePath;
-        Module::createDir(dirname($target));
-        copy($source, $target);
-
-        return [
-            'path'   => $relativePath,
-            'name'   => $fileName,
-            'source' => $link,
-        ];
-    }
-
-    /**
-     * @throws HelperException
-     */
-    protected function savePostTextImages(
-        int    $blogId,
-        int    $postId,
-        array  $fieldsForSave,
-        array  $textImages,
-        string $exchangeDir = ''
-    ): void
-    {
-        if (empty($textImages)) {
-            return;
-        }
-
-        $updates = [];
-        foreach (['DETAIL_TEXT', 'PREVIEW_TEXT'] as $fieldName) {
-            if (!array_key_exists($fieldName, $fieldsForSave)) {
-                continue;
-            }
-
-            $updates[$fieldName] = (string)$fieldsForSave[$fieldName];
-        }
-
-        if (empty($updates)) {
-            return;
-        }
-
-        $imageMap = $this->importPostBlogImages(
-            $blogId,
-            $postId,
-            (int)$fieldsForSave['AUTHOR_ID'],
-            $textImages['BLOG_IMAGES'] ?? [],
-            $exchangeDir
-        );
-        $linkMap = $this->importPostTextFileLinks($textImages['FILE_LINKS'] ?? [], $exchangeDir);
-
-        foreach ($updates as $fieldName => $text) {
-            $text = $this->replacePostBlogImageIds($text, $imageMap);
-            $text = str_replace(array_keys($linkMap), array_values($linkMap), $text);
-            $updates[$fieldName] = $text;
-        }
-
-        $result = CBlogPost::Update($postId, $updates);
-        if (!$result) {
-            $this->throwApplicationExceptionIfExists();
-            throw new HelperException("Blog post \"$postId\" text images not updated");
-        }
-    }
-
-    protected function importPostBlogImages(
-        int    $blogId,
-        int    $postId,
-        int    $authorId,
-        array  $blogImages,
-        string $exchangeDir = ''
-    ): array
-    {
-        if (empty($blogImages)) {
-            return [];
-        }
-
-        $this->deletePostBlogImages($blogId, $postId);
-
-        $result = [];
-        foreach ($blogImages as $oldImageId => $image) {
-            if (empty($image['FILE']) || !is_array($image['FILE'])) {
-                continue;
-            }
-
-            $file = $this->makeFileArrayByRef($image['FILE'], $exchangeDir);
-            if (!$file) {
-                continue;
-            }
-
-            $userId = $authorId;
-            if (!empty($image['USER_LOGIN'])) {
-                $userId = $this->userHelper->getUserIdByLogin((string)$image['USER_LOGIN']);
-            }
-
-            $newImageId = CBlogImage::Add([
-                'BLOG_ID'    => $blogId,
-                'POST_ID'    => $postId,
-                'USER_ID'    => $userId,
-                'TITLE'      => $image['TITLE'] ?? '',
-                'IMAGE_SIZE' => $image['IMAGE_SIZE'] ?? ($file['size'] ?? ''),
-                'IS_COMMENT' => 'N',
-                'FILE_ID'    => $file,
-            ]);
-
-            if ($newImageId) {
-                $result[(int)$oldImageId] = (int)$newImageId;
-            }
-        }
-
-        return $result;
-    }
-
-    protected function deletePostBlogImages(int $blogId, int $postId): void
-    {
-        $dbres = CBlogImage::GetList(
-            ['ID' => 'ASC'],
-            [
-                'BLOG_ID'    => $blogId,
-                'POST_ID'    => $postId,
-                'IS_COMMENT' => 'N',
-            ],
-            false,
-            false,
-            ['ID']
-        );
-
-        while ($image = $dbres->Fetch()) {
-            CBlogImage::Delete((int)$image['ID']);
-        }
-    }
-
-    protected function replacePostBlogImageIds(string $text, array $imageMap): string
-    {
-        if (empty($imageMap)) {
-            return $text;
-        }
-
-        return preg_replace_callback(
-            '/\[IMG\s+ID=(\d+)([^\]]*)\]/i',
-            function ($matches) use ($imageMap) {
-                $oldImageId = (int)$matches[1];
-                if (empty($imageMap[$oldImageId])) {
-                    return $matches[0];
-                }
-
-                return '[IMG ID=' . $imageMap[$oldImageId] . ($matches[2] ?? '') . ']';
-            },
-            $text
-        );
-    }
-
-    protected function importPostTextFileLinks(array $fileLinks, string $exchangeDir = ''): array
-    {
-        $result = [];
-        foreach ($fileLinks as $oldLink => $fileRef) {
-            if (!is_array($fileRef)) {
-                continue;
-            }
-
-            $newLink = $this->restoreFileRefToUpload($fileRef, $exchangeDir, 'sprint_migration/blog_post_text');
-            if ($newLink) {
-                $result[$oldLink] = $newLink;
-            }
-        }
-
-        return $result;
-    }
-
-    protected function restoreFileRefToUpload(array $fileRef, string $exchangeDir = '', string $subdir = 'sprint_migration'): string
-    {
-        if (empty($fileRef['path']) || $exchangeDir === '') {
-            return '';
-        }
-
-        $source = rtrim($exchangeDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . ltrim($fileRef['path'], DIRECTORY_SEPARATOR);
-        if (!is_file($source)) {
-            return '';
-        }
-
-        $fileName = basename($fileRef['name'] ?? $source);
-        $relativePath = '/upload/' . trim($subdir, '/') . '/' . md5((string)$fileRef['path']) . '_' . $fileName;
-        $target = Module::getDocRoot() . $relativePath;
-        Module::createDir(dirname($target));
-        copy($source, $target);
-
-        return $relativePath;
     }
 
     protected function exportPostCategories(int $blogId, int $postId): array
@@ -1447,8 +1076,6 @@ class BlogHelper extends Helper
             'CATEGORIES'        => [],
             'PERMS_POST'        => [],
             'PERMS_COMMENT'     => [],
-            'UF_VALUES'         => [],
-            'TEXT_IMAGES'       => [],
         ];
     }
 

--- a/templates/BlogPostExport.php
+++ b/templates/BlogPostExport.php
@@ -3,8 +3,6 @@
 /**
  * @var $version
  * @var $description
- * @var $blog
- * @var $posts
  * @var $extendUse
  * @var $extendClass
  * @var $moduleVersion
@@ -33,16 +31,16 @@ class <?php echo $version ?> extends <?php echo $extendClass ?>
      */
     public function up()
     {
-        $helper = $this->getHelperManager();
-        $exchangeDir = $this->getVersionConfig()->getVersionExchangeDir($this->getVersionName());
-
-        $blogId = $helper->Blog()->getBlogId(<?php echo var_export($blog['URL'], 1) ?>);
-        if (!$blogId) {
-            throw new Exceptions\HelperException('Blog <?php echo addslashes($blog['URL']) ?> not found');
-        }
-
-<?php foreach ($posts as $post) { ?>
-        $helper->Blog()->savePost($blogId, <?php echo var_export($post, 1) ?>, $exchangeDir);
-<?php } ?>
+        $this->getExchangeManager()
+             ->BlogPostsImport()
+             ->setLimit(20)
+             ->execute(function ($item) {
+                 $this->getHelperManager()
+                      ->Blog()
+                      ->savePost(
+                          $item['blog_id'],
+                          $item['fields']
+                      );
+             });
     }
 }


### PR DESCRIPTION
### Что сделано

  Добавлен перенос записей блога через XML exchange-контур по аналогии с элементами инфоблока.

  ### Как работает

  - Экспорт записей блога теперь пишет данные в `blog_posts.xml` через `RestartableWriter`.
  - Импорт выполняется через `ExchangeManager::BlogPostsImport()`.
  - Директория exchange скрыта внутри reader/writer слоя и не передается в публичный `BlogHelper`.
  - В шаблоне миграции используется restartable-импорт с `setLimit(20)`, это размер пачки, а не ограничение общего количества записей.
  - Сохранен выбор записей для миграции:
    - все записи;
    - список ID;
    - список CODE.

  ### Что переносится

  - основные поля записи блога;
  - `ATTACH_IMG`;
  - категории;
  - права на запись и комментарии;
  - пользовательские поля `UF_*`, включая файловые и списочные значения.

  ### Что изменено в контракте

  - Старый inline-экспорт записей в PHP-массивы заменен на XML.
  - Старый проброс `exchangeDir` в методы `BlogHelper` удален.
  - `UF_*` пишутся в XML отдельными полями.
  - `exportPosts()` удален как неиспользуемый legacy-метод.
  - `exportPostById()` оставлен только как внутренний метод для сравнения существующей записи при обновлении.

  ### Ограничения

  Картинки и файлы, встроенные внутрь `DETAIL_TEXT` / `PREVIEW_TEXT`, в этом PR не переносятся.