### PR TITLE
Feature/xml file s3 exchange

### DIFF
--- a/lib/exchange/fileexchange.php
+++ b/lib/exchange/fileexchange.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Sprint\Migration\Exchange;
+
+use CFile;
+use Sprint\Migration\Exceptions\MigrationException;
+use Sprint\Migration\Module;
+
+class FileExchange
+{
+    /**
+     * @throws MigrationException
+     */
+    public function copyFileToExchange(array $file, string $exchangeDir): void
+    {
+        if (empty($file['SUBDIR']) || empty($file['FILE_NAME'])) {
+            return;
+        }
+
+        $source = $this->getSourcePath($file);
+        if ($source === '' || !is_file($source)) {
+            return;
+        }
+
+        $target = rtrim($exchangeDir, DIRECTORY_SEPARATOR)
+            . DIRECTORY_SEPARATOR
+            . trim($file['SUBDIR'], DIRECTORY_SEPARATOR)
+            . DIRECTORY_SEPARATOR
+            . $file['FILE_NAME'];
+
+        Module::createDir(dirname($target));
+        copy($source, $target);
+    }
+
+    public function makeFileArray(string $path, array $attributes = []): false|array
+    {
+        $file = CFile::MakeFileArray($path);
+        if (empty($file)) {
+            return false;
+        }
+
+        if (!empty($attributes['name'])) {
+            $file['name'] = $attributes['name'];
+        }
+        if (!empty($attributes['description'])) {
+            $file['description'] = $attributes['description'];
+        }
+        if (!empty($attributes['content_type'])) {
+            $file['type'] = $attributes['content_type'];
+        }
+
+        return $file;
+    }
+
+    private function getSourcePath(array $file): string
+    {
+        if (!empty($file['ID'])) {
+            $fileArray = CFile::MakeFileArray((int)$file['ID']);
+            $tmpName = (string)($fileArray['tmp_name'] ?? '');
+            if ($tmpName !== '' && is_file($tmpName)) {
+                return $tmpName;
+            }
+        }
+
+        return $this->getLocalSourcePath($file);
+    }
+
+    private function getLocalSourcePath(array $file): string
+    {
+        if (empty($file['SRC'])) {
+            return '';
+        }
+
+        $src = (string)$file['SRC'];
+        if (str_starts_with($src, 'http://') || str_starts_with($src, 'https://')) {
+            return '';
+        }
+
+        return Module::getDocRoot() . rawurldecode($src);
+    }
+}

--- a/lib/exchange/fileexchange.php
+++ b/lib/exchange/fileexchange.php
@@ -54,28 +54,13 @@ class FileExchange
 
     private function getSourcePath(array $file): string
     {
-        if (!empty($file['ID'])) {
-            $fileArray = CFile::MakeFileArray((int)$file['ID']);
-            $tmpName = (string)($fileArray['tmp_name'] ?? '');
-            if ($tmpName !== '' && is_file($tmpName)) {
-                return $tmpName;
-            }
-        }
-
-        return $this->getLocalSourcePath($file);
-    }
-
-    private function getLocalSourcePath(array $file): string
-    {
-        if (empty($file['SRC'])) {
+        if (empty($file['ID'])) {
             return '';
         }
 
-        $src = (string)$file['SRC'];
-        if (str_starts_with($src, 'http://') || str_starts_with($src, 'https://')) {
-            return '';
-        }
+        $fileArray = CFile::MakeFileArray((int)$file['ID']);
+        $tmpName = (string)($fileArray['tmp_name'] ?? '');
 
-        return Module::getDocRoot() . rawurldecode($src);
+        return ($tmpName !== '' && is_file($tmpName)) ? $tmpName : '';
     }
 }

--- a/lib/exchange/reader.php
+++ b/lib/exchange/reader.php
@@ -2,7 +2,6 @@
 
 namespace Sprint\Migration\Exchange;
 
-use CFile;
 use Sprint\Migration\Exceptions\HelperException;
 use Sprint\Migration\Exceptions\MigrationException;
 use Sprint\Migration\Locale;
@@ -206,17 +205,11 @@ class Reader
             return false;
         }
 
-        $file = CFile::MakeFileArray($this->path . '/' . $value);
+        $file = (new FileExchange())->makeFileArray($this->path . '/' . $value, $attrs);
         if (empty($file)) {
             return false;
         }
 
-        if (!empty($attrs['name'])) {
-            $file['name'] = $attrs['name'];
-        }
-        if (!empty($attrs['description'])) {
-            $file['description'] = $attrs['description'];
-        }
         return $file;
     }
 }

--- a/lib/exchange/writer.php
+++ b/lib/exchange/writer.php
@@ -71,13 +71,9 @@ class Writer
      */
     private function copyTagsFiles(WriterTag $tag): void
     {
+        $fileExchange = new FileExchange();
         foreach ($tag->getFiles() as $file) {
-            $filePath = Module::getDocRoot() . $file['SRC'];
-            if (file_exists($filePath)) {
-                $newPath = $this->getFileDir() . '/' . $file['SUBDIR'] . '/' . $file['FILE_NAME'];
-                Module::createDir(dirname($newPath));
-                copy($filePath, $newPath);
-            }
+            $fileExchange->copyFileToExchange($file, $this->getFileDir());
         }
 
     }

--- a/lib/exchange/writertag.php
+++ b/lib/exchange/writertag.php
@@ -135,9 +135,10 @@ class WriterTag
         $this->addValueTag(
             $file['SUBDIR'] . '/' . $file['FILE_NAME'],
             [
-                'name'        => $file['ORIGINAL_NAME'],
-                'description' => $file['DESCRIPTION'],
-                'type'        => 'file',
+                'name'         => $file['ORIGINAL_NAME'],
+                'description'  => $file['DESCRIPTION'],
+                'content_type' => $file['CONTENT_TYPE'] ?? '',
+                'type'         => 'file',
             ]
         );
 


### PR DESCRIPTION
## Что сделано

  Добавлена поддержка файлов из S3/cloud-хранилища Битрикса в общем XML exchange-слое.

  Изменение работает универсально для всех XML-миграций, которые используют `WriterTag::addFile()`:
  - `PREVIEW_PICTURE`;
  - `DETAIL_PICTURE`;
  - файловые свойства инфоблока;
  - файловые UF-поля HL-блоков;
  - медиабиблиотека;
  - другие XML-экспорты, использующие общий `Writer/Reader`.

  ## Как работает

  Добавлен небольшой `FileExchange`, который используется внутри общего XML `Writer/Reader`.

  При экспорте файла:
  - `WriterTag` по-прежнему пишет `<value type="file">`;
  - `Writer` передает файл в `FileExchange`;
  - `FileExchange` сначала получает источник через `CFile::MakeFileArray(ID)`;
  - для файлов в S3/cloud-хранилище Bitrix возвращает локальный временный `tmp_name`;
  - файл копируется в exchange-пакет уже из локального временного файла.

  При импорте:
  - `Reader` собирает file-array через `FileExchange`;
  - восстанавливаются `name`, `description` и `content_type`.