### PR TITLE
Проверка директории конфига

### DIFF
--- a/lib/configmanager.php
+++ b/lib/configmanager.php
@@ -107,8 +107,10 @@ class ConfigManager
         );
 
         foreach ($events as $aEvent) {
-            $customPath = (string)ExecuteModuleEventEx($aEvent);
-            $this->addFromDirectory($customPath);
+            $customPath = ExecuteModuleEventEx($aEvent);
+            if ($customPath !== null) {
+                $this->addFromDirectory((string)$customPath);
+            }
         }
 
         return $this;


### PR DESCRIPTION
Проблема: если есть событие, модуль которого не установлен на портале, ловим ошибку [ValueError] DirectoryIterator::__construct(): Argument 1 ($directory) cannot be empty (0) in .../configmanager.php:122. Это происходит из-за того, что битрикс в случае неудачного подключения модуля в методе ExecuteModuleEventEx - возвращает null, а в ConfigManager это приводится к строке. По итогу получаем пустую строку. Выявили проблему при многосайтовости -  когда у нас есть модуль, который установлен на одном из порталов, и при этом его нет на другом.